### PR TITLE
chore(deps-dev): bump textlint packages

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -20,9 +20,9 @@
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.8",
-        "@textlint-ja/textlint-rule-preset-ai-writing": "^1.6.1",
+        "@textlint-ja/textlint-rule-preset-ai-writing": "^1.6.3",
         "hygen": "^6.2.11",
-        "textlint": "^15.5.1",
+        "textlint": "^15.5.4",
         "typescript": "^5.9.3"
       }
     },
@@ -1088,9 +1088,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.13",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
+      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1724,9 +1724,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
-      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2333,9 +2333,9 @@
       }
     },
     "node_modules/@textlint-ja/textlint-rule-preset-ai-writing": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@textlint-ja/textlint-rule-preset-ai-writing/-/textlint-rule-preset-ai-writing-1.6.1.tgz",
-      "integrity": "sha512-UvWK2UnYwObEHh1yP4tbHmWc1UBYRUIaeiSBdBz8pS6Ks+SEMq7u2ZMqYY2kh2e2VjoBidvu28+eN1g2YzXQjw==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@textlint-ja/textlint-rule-preset-ai-writing/-/textlint-rule-preset-ai-writing-1.6.3.tgz",
+      "integrity": "sha512-QQxO3sK6mGQyPS753jZ2zIy0EgAQHqiJ3oadnwV/hs5sOZn2WOqHWNAnjwEXLYiFNvI53zVMTiabL31cJPigiw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2345,109 +2345,109 @@
       }
     },
     "node_modules/@textlint/ast-node-types": {
-      "version": "15.5.2",
-      "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-15.5.2.tgz",
-      "integrity": "sha512-fCaOxoup5LIyBEo7R1oYWE7V4bSX0KQeHh66twon9e9usaLE3ijgF8QjYsR6joCssdeCHVd0wHm7ppsEyTr6vg==",
+      "version": "15.5.4",
+      "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-15.5.4.tgz",
+      "integrity": "sha512-bVtB6VEy9U9DpW8cTt25k5T+lz86zV5w6ImePZqY1AXzSuPhqQNT77lkMPxonXzUducEIlSvUu3o7sKw3y9+Sw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@textlint/ast-tester": {
-      "version": "15.5.2",
-      "resolved": "https://registry.npmjs.org/@textlint/ast-tester/-/ast-tester-15.5.2.tgz",
-      "integrity": "sha512-xlGt3fEUC9NkGNmd7WIzIoQvxs/fOISvrco6fedSCCji0iqVwc6fw4atb2iTM/eGg4IbPlBVpjnLBduB5FpekA==",
+      "version": "15.5.4",
+      "resolved": "https://registry.npmjs.org/@textlint/ast-tester/-/ast-tester-15.5.4.tgz",
+      "integrity": "sha512-5XOZP84GhqBQgs9JKxYOw2nCX/b+ql9kqZRrxadCKdB/XwUHXk9jKv+aQCDh0GB3FRlP77Ob1dGlsnLkyxrbkg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@textlint/ast-node-types": "15.5.2",
+        "@textlint/ast-node-types": "15.5.4",
         "debug": "^4.4.3"
       }
     },
     "node_modules/@textlint/ast-traverse": {
-      "version": "15.5.2",
-      "resolved": "https://registry.npmjs.org/@textlint/ast-traverse/-/ast-traverse-15.5.2.tgz",
-      "integrity": "sha512-8lpRDjFAN+I/4hGo+0YRIpsk1YfiI223oulFkb8gL0/PCGrdw798mfV+czKIS0/fr1Eq/fYbOzbHpoATDA4GBA==",
+      "version": "15.5.4",
+      "resolved": "https://registry.npmjs.org/@textlint/ast-traverse/-/ast-traverse-15.5.4.tgz",
+      "integrity": "sha512-j6ToGmPUyNkp2FCJ0vlRnx1EPlPM19/XFyY9l95ToJ9XJZSGf3tcEa2CP8laZy9yuTVcGYDvQp2RdV3NxjbZpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@textlint/ast-node-types": "15.5.2"
+        "@textlint/ast-node-types": "15.5.4"
       }
     },
     "node_modules/@textlint/config-loader": {
-      "version": "15.5.2",
-      "resolved": "https://registry.npmjs.org/@textlint/config-loader/-/config-loader-15.5.2.tgz",
-      "integrity": "sha512-9DiYEyX4BUx8cNqnFyYv0yF/Ckt+A23pCOaAE13iWCmKXOMTyGLxr0CnqB+pB4cDmRUykYJgI9Rvp5jQyYCu/w==",
+      "version": "15.5.4",
+      "resolved": "https://registry.npmjs.org/@textlint/config-loader/-/config-loader-15.5.4.tgz",
+      "integrity": "sha512-jlCfkYp3ICwPTSeBbnfYn04Q4vMzCWi3AsmPC3JSTmyNuHXnij/6Gb9AfCB3kl9K23iNmtSHNBnbv5j9i8QqvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@textlint/kernel": "15.5.2",
-        "@textlint/module-interop": "15.5.2",
-        "@textlint/resolver": "15.5.2",
-        "@textlint/types": "15.5.2",
-        "@textlint/utils": "15.5.2",
+        "@textlint/kernel": "15.5.4",
+        "@textlint/module-interop": "15.5.4",
+        "@textlint/resolver": "15.5.4",
+        "@textlint/types": "15.5.4",
+        "@textlint/utils": "15.5.4",
         "debug": "^4.4.3",
-        "rc-config-loader": "^4.1.3"
+        "rc-config-loader": "^4.1.4"
       }
     },
     "node_modules/@textlint/feature-flag": {
-      "version": "15.5.2",
-      "resolved": "https://registry.npmjs.org/@textlint/feature-flag/-/feature-flag-15.5.2.tgz",
-      "integrity": "sha512-1KYloMwk20rkrqES15O+wSVUIPk/Vg1ol3zdtp6vT3E43Yj7mlQPwHkTr0J/XSmoJdm/s8cn86ds/KgWrm+i+g==",
+      "version": "15.5.4",
+      "resolved": "https://registry.npmjs.org/@textlint/feature-flag/-/feature-flag-15.5.4.tgz",
+      "integrity": "sha512-Jw0uTRwxq9CZzkiP8PzNiertZ+j48Zo2Kb5uxDpGizNEjExgpemOCu3dZkc4lKy8e2W9M8lSrP4kO8rK2Dp9Pg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@textlint/fixer-formatter": {
-      "version": "15.5.2",
-      "resolved": "https://registry.npmjs.org/@textlint/fixer-formatter/-/fixer-formatter-15.5.2.tgz",
-      "integrity": "sha512-zVJTrrsSRVnZULQAI7qbE8RIVPlpGKKkvCFVfm8jSOjgXdAz3gOy4VmYxLWPLlvihB4KT9y9PmvFv47q23iQnw==",
+      "version": "15.5.4",
+      "resolved": "https://registry.npmjs.org/@textlint/fixer-formatter/-/fixer-formatter-15.5.4.tgz",
+      "integrity": "sha512-wG/FLzcoI9pGsTL11lraS/QdagyVpIxollAADsXCVbna5eAaqqtOeX2dCYZ6l4sNY/PteD3h02FjUfUjVNwNrw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@textlint/module-interop": "15.5.2",
-        "@textlint/resolver": "15.5.2",
-        "@textlint/types": "15.5.2",
+        "@textlint/module-interop": "15.5.4",
+        "@textlint/resolver": "15.5.4",
+        "@textlint/types": "15.5.4",
         "chalk": "^4.1.2",
         "debug": "^4.4.3",
-        "diff": "^8.0.3",
+        "diff": "^8.0.4",
         "string-width": "^4.2.3",
         "strip-ansi": "^6.0.1",
         "text-table": "^0.2.0"
       }
     },
     "node_modules/@textlint/kernel": {
-      "version": "15.5.2",
-      "resolved": "https://registry.npmjs.org/@textlint/kernel/-/kernel-15.5.2.tgz",
-      "integrity": "sha512-UyDgebb5TQnZiFGGlF5yRIDXzvPa7TF+0ProCvrOp7/w88beZOkCx4YY53h5q69DdlKMOyUI9AdMjqLzpfzvnA==",
+      "version": "15.5.4",
+      "resolved": "https://registry.npmjs.org/@textlint/kernel/-/kernel-15.5.4.tgz",
+      "integrity": "sha512-IZSChEFO1Yei1rr0WOTO4JnVjDuz8tlay9gTvqJmvNCe8IcFAbUtlb5gkFP1t57Pix5xXhkUY8HuNICedg67DQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@textlint/ast-node-types": "15.5.2",
-        "@textlint/ast-tester": "15.5.2",
-        "@textlint/ast-traverse": "15.5.2",
-        "@textlint/feature-flag": "15.5.2",
-        "@textlint/source-code-fixer": "15.5.2",
-        "@textlint/types": "15.5.2",
-        "@textlint/utils": "15.5.2",
+        "@textlint/ast-node-types": "15.5.4",
+        "@textlint/ast-tester": "15.5.4",
+        "@textlint/ast-traverse": "15.5.4",
+        "@textlint/feature-flag": "15.5.4",
+        "@textlint/source-code-fixer": "15.5.4",
+        "@textlint/types": "15.5.4",
+        "@textlint/utils": "15.5.4",
         "debug": "^4.4.3",
         "fast-equals": "^4.0.3",
         "structured-source": "^4.0.0"
       }
     },
     "node_modules/@textlint/linter-formatter": {
-      "version": "15.5.2",
-      "resolved": "https://registry.npmjs.org/@textlint/linter-formatter/-/linter-formatter-15.5.2.tgz",
-      "integrity": "sha512-jAw7jWM8+wU9cG6Uu31jGyD1B+PAVePCvnPKC/oov+2iBPKk3ao30zc/Itmi7FvXo4oPaL9PmzPPQhyniPVgVg==",
+      "version": "15.5.4",
+      "resolved": "https://registry.npmjs.org/@textlint/linter-formatter/-/linter-formatter-15.5.4.tgz",
+      "integrity": "sha512-D9qJedKBLmAo+kiudop4UKgSxXMi4O8U86KrCidVXZ9RsK0NSVIw6+r2rlMUOExq79iEY81FRENyzmNVRxDBsg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@azu/format-text": "^1.0.2",
         "@azu/style-format": "^1.0.1",
-        "@textlint/module-interop": "15.5.2",
-        "@textlint/resolver": "15.5.2",
-        "@textlint/types": "15.5.2",
+        "@textlint/module-interop": "15.5.4",
+        "@textlint/resolver": "15.5.4",
+        "@textlint/types": "15.5.4",
         "chalk": "^4.1.2",
         "debug": "^4.4.3",
         "js-yaml": "^4.1.1",
-        "lodash": "^4.17.23",
+        "lodash": "^4.18.1",
         "pluralize": "^2.0.0",
         "string-width": "^4.2.3",
         "strip-ansi": "^6.0.1",
@@ -2456,13 +2456,13 @@
       }
     },
     "node_modules/@textlint/markdown-to-ast": {
-      "version": "15.5.2",
-      "resolved": "https://registry.npmjs.org/@textlint/markdown-to-ast/-/markdown-to-ast-15.5.2.tgz",
-      "integrity": "sha512-eLEeIb7jcyWiG1jahr3pl3z8dEYEgLPdz7lBG3AP8aB4m8Sv0SdL0mCD0tfR5hNp8FrOEXldqh1g2PMuiXlN3w==",
+      "version": "15.5.4",
+      "resolved": "https://registry.npmjs.org/@textlint/markdown-to-ast/-/markdown-to-ast-15.5.4.tgz",
+      "integrity": "sha512-BBAmPYAQ2Y3sqJoivT7S+tTqksoKKi2qwLOPRYVPcAM55B3x/8eLxQDd0qARo7XvJKscDawwpfAGcLOR9n6SBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@textlint/ast-node-types": "15.5.2",
+        "@textlint/ast-node-types": "15.5.4",
         "debug": "^4.4.3",
         "mdast-util-gfm-autolink-literal": "^0.1.3",
         "neotraverse": "^0.6.18",
@@ -3063,9 +3063,9 @@
       }
     },
     "node_modules/@textlint/module-interop": {
-      "version": "15.5.2",
-      "resolved": "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-15.5.2.tgz",
-      "integrity": "sha512-mg6rMQ3+YjwiXCYoQXbyVfDucpTa1q5mhspd/9qHBxUq4uY6W8GU42rmT3GW0V1yOfQ9z/iRrgPtkp71s8JzXg==",
+      "version": "15.5.4",
+      "resolved": "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-15.5.4.tgz",
+      "integrity": "sha512-JyAUd26ll3IFF87LP0uGoa8Tzw5ZKiYvGs6v8jLlzyND1lUYCI4+2oIAslrODLkf0qwoCaJrBQWM3wsw+asVGQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -3083,69 +3083,69 @@
       }
     },
     "node_modules/@textlint/resolver": {
-      "version": "15.5.2",
-      "resolved": "https://registry.npmjs.org/@textlint/resolver/-/resolver-15.5.2.tgz",
-      "integrity": "sha512-YEITdjRiJaQrGLUWxWXl4TEg+d2C7+TNNjbGPHPH7V7CCnXm+S9GTjGAL7Q2WSGJyFEKt88Jvx6XdJffRv4HEA==",
+      "version": "15.5.4",
+      "resolved": "https://registry.npmjs.org/@textlint/resolver/-/resolver-15.5.4.tgz",
+      "integrity": "sha512-5GUagtpQuYcmhlOzBGdmVBvDu5lKgVTjwbxtdfoidN4OIqblIxThJHHjazU+ic+/bCIIzI2JcOjHGSaRmE8Gcg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@textlint/source-code-fixer": {
-      "version": "15.5.2",
-      "resolved": "https://registry.npmjs.org/@textlint/source-code-fixer/-/source-code-fixer-15.5.2.tgz",
-      "integrity": "sha512-9MMhrvX4uQOEYM+C3kbVsq1O2U7tOTc0l3rMiJzniwqq57AgP/AxDRz20ujh2OGE7Qw4E2y8KyM/3XMi0HvUHQ==",
+      "version": "15.5.4",
+      "resolved": "https://registry.npmjs.org/@textlint/source-code-fixer/-/source-code-fixer-15.5.4.tgz",
+      "integrity": "sha512-IVBpT4chGOtTGCs29NRpeaDVC+bxFRnnyPWsFEkCX5a/uDFwJuVsBcm4KxdgTLgOac5tOCjKa+/6e+HohnnkLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@textlint/types": "15.5.2",
+        "@textlint/types": "15.5.4",
         "debug": "^4.4.3"
       }
     },
     "node_modules/@textlint/text-to-ast": {
-      "version": "15.5.2",
-      "resolved": "https://registry.npmjs.org/@textlint/text-to-ast/-/text-to-ast-15.5.2.tgz",
-      "integrity": "sha512-7cFC1Em9W3g8ilrelDftGmRzlwG+5+jx2HLJ4h4uAl+Ib42bfCtDdBnvh3dRomgu4Z36Tj0F3qMBFgxNoQhZeA==",
+      "version": "15.5.4",
+      "resolved": "https://registry.npmjs.org/@textlint/text-to-ast/-/text-to-ast-15.5.4.tgz",
+      "integrity": "sha512-9Vhjd0Ri/J85mwr1sX7MMfG52NS3ytOF+nTyXBYTtOLZ63G46ySWWr34y+/v+IBYjUelfY+sxC0bs9OZwVOn2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@textlint/ast-node-types": "15.5.2"
+        "@textlint/ast-node-types": "15.5.4"
       }
     },
     "node_modules/@textlint/textlint-plugin-markdown": {
-      "version": "15.5.2",
-      "resolved": "https://registry.npmjs.org/@textlint/textlint-plugin-markdown/-/textlint-plugin-markdown-15.5.2.tgz",
-      "integrity": "sha512-aaXWlFmhX+8uUibMX/+nUvqH2/C/SptW24YFUVMhCLPiEtfiYsZbT8qVtuYMH6L/MXAzjOgVSRuDcceoI7csJA==",
+      "version": "15.5.4",
+      "resolved": "https://registry.npmjs.org/@textlint/textlint-plugin-markdown/-/textlint-plugin-markdown-15.5.4.tgz",
+      "integrity": "sha512-j9csK+Tsl6wc4PfTwqOo4Ol2m/W/iSEvrojzuwqMHGQEIRpIKEF0pRsSS2U9b9y6OLLMBRFwEFJ+TOM7R7uvjQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@textlint/markdown-to-ast": "15.5.2",
-        "@textlint/types": "15.5.2"
+        "@textlint/markdown-to-ast": "15.5.4",
+        "@textlint/types": "15.5.4"
       }
     },
     "node_modules/@textlint/textlint-plugin-text": {
-      "version": "15.5.2",
-      "resolved": "https://registry.npmjs.org/@textlint/textlint-plugin-text/-/textlint-plugin-text-15.5.2.tgz",
-      "integrity": "sha512-KlXPdhz5AFoBAu0bYqBuwz0ws0P5ACmXs7BFoc8719o+nK+ONSgQ+UEyl89NzGepweIqQHnlxTGcibvxu0z8Ew==",
+      "version": "15.5.4",
+      "resolved": "https://registry.npmjs.org/@textlint/textlint-plugin-text/-/textlint-plugin-text-15.5.4.tgz",
+      "integrity": "sha512-5Rghi/o9IWY/IO4kuqeNfwl4fCD5LxGCQOv09k8lsWrXNUZRUuJEyqrCW4cSKwpX1RgnHNK49Tt75BNjAq44pQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@textlint/text-to-ast": "15.5.2",
-        "@textlint/types": "15.5.2"
+        "@textlint/text-to-ast": "15.5.4",
+        "@textlint/types": "15.5.4"
       }
     },
     "node_modules/@textlint/types": {
-      "version": "15.5.2",
-      "resolved": "https://registry.npmjs.org/@textlint/types/-/types-15.5.2.tgz",
-      "integrity": "sha512-sJOrlVLLXp4/EZtiWKWq9y2fWyZlI8GP+24rnU5avtPWBIMm/1w97yzKrAqYF8czx2MqR391z5akhnfhj2f/AQ==",
+      "version": "15.5.4",
+      "resolved": "https://registry.npmjs.org/@textlint/types/-/types-15.5.4.tgz",
+      "integrity": "sha512-mY28j2U7nrWmZbxyKnRvB8vJxJab4AxqOobLfb6iozrLelJbqxcOTvBQednadWPfAk9XWaZVMqUr9Nird3mutg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@textlint/ast-node-types": "15.5.2"
+        "@textlint/ast-node-types": "15.5.4"
       }
     },
     "node_modules/@textlint/utils": {
-      "version": "15.5.2",
-      "resolved": "https://registry.npmjs.org/@textlint/utils/-/utils-15.5.2.tgz",
-      "integrity": "sha512-g7Zs8QDZJspno9C7i5iGdwuJ07SxCHWIgxpAebwX503sup4w5IOo3q0X/LxRdl1F4sSAFw/m2glYZomOieNPCw==",
+      "version": "15.5.4",
+      "resolved": "https://registry.npmjs.org/@textlint/utils/-/utils-15.5.4.tgz",
+      "integrity": "sha512-lz/EClunydTwr1pbOpw8OZ28n4JDW/WwvWjyUa1WxwQI6KWMvTAASjVZ+9CS6IceIlIA4xqLmk9Oi3gms9/x7g==",
       "dev": true,
       "license": "MIT"
     },
@@ -4536,9 +4536,9 @@
       }
     },
     "node_modules/content-disposition": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
-      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5439,9 +5439,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
-      "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -6029,9 +6029,9 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
-      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7088,9 +7088,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.8",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
-      "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7825,9 +7825,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -10174,9 +10174,9 @@
       "license": "MIT"
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -10440,9 +10440,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -11392,14 +11392,14 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -11828,33 +11828,33 @@
       "license": "MIT"
     },
     "node_modules/textlint": {
-      "version": "15.5.2",
-      "resolved": "https://registry.npmjs.org/textlint/-/textlint-15.5.2.tgz",
-      "integrity": "sha512-L0Z00xDx4mI3L44nBO5v/Z00ZIhX932dKNwRpSpwGGCWTHFJ7tx1imfTQH441xXb/EhuqnrHhchtSs/WBuJEnQ==",
+      "version": "15.5.4",
+      "resolved": "https://registry.npmjs.org/textlint/-/textlint-15.5.4.tgz",
+      "integrity": "sha512-W7pJKjeNyRfyzE9gLVfFE3stscas1dcNqDvge2WTkDxroa5FklKtrHYBa8sG8z2BWAJvbqOH/d29dRPzEww0FA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.26.0",
-        "@textlint/ast-node-types": "15.5.2",
-        "@textlint/ast-traverse": "15.5.2",
-        "@textlint/config-loader": "15.5.2",
-        "@textlint/feature-flag": "15.5.2",
-        "@textlint/fixer-formatter": "15.5.2",
-        "@textlint/kernel": "15.5.2",
-        "@textlint/linter-formatter": "15.5.2",
-        "@textlint/module-interop": "15.5.2",
-        "@textlint/resolver": "15.5.2",
-        "@textlint/textlint-plugin-markdown": "15.5.2",
-        "@textlint/textlint-plugin-text": "15.5.2",
-        "@textlint/types": "15.5.2",
-        "@textlint/utils": "15.5.2",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@textlint/ast-node-types": "15.5.4",
+        "@textlint/ast-traverse": "15.5.4",
+        "@textlint/config-loader": "15.5.4",
+        "@textlint/feature-flag": "15.5.4",
+        "@textlint/fixer-formatter": "15.5.4",
+        "@textlint/kernel": "15.5.4",
+        "@textlint/linter-formatter": "15.5.4",
+        "@textlint/module-interop": "15.5.4",
+        "@textlint/resolver": "15.5.4",
+        "@textlint/textlint-plugin-markdown": "15.5.4",
+        "@textlint/textlint-plugin-text": "15.5.4",
+        "@textlint/types": "15.5.4",
+        "@textlint/utils": "15.5.4",
         "debug": "^4.4.3",
         "file-entry-cache": "^10.1.4",
         "glob": "^11.1.0",
         "md5": "^2.3.0",
         "optionator": "^0.9.4",
         "path-to-glob-pattern": "^2.0.1",
-        "rc-config-loader": "^4.1.3",
+        "rc-config-loader": "^4.1.4",
         "read-package-up": "^11.0.0",
         "structured-source": "^4.0.0",
         "zod": "^3.25.76"
@@ -13404,13 +13404,13 @@
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.25.1",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
-      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "dev": true,
       "license": "ISC",
       "peerDependencies": {
-        "zod": "^3.25 || ^4"
+        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/zwitch": {

--- a/app/package.json
+++ b/app/package.json
@@ -30,9 +30,9 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.8",
-    "@textlint-ja/textlint-rule-preset-ai-writing": "^1.6.1",
+    "@textlint-ja/textlint-rule-preset-ai-writing": "^1.6.3",
     "hygen": "^6.2.11",
-    "textlint": "^15.5.1",
+    "textlint": "^15.5.4",
     "typescript": "^5.9.3"
   }
 }


### PR DESCRIPTION
## Summary
- `@textlint-ja/textlint-rule-preset-ai-writing` 1.6.1 → 1.6.3
- `textlint` 15.5.2 → 15.5.4

Dependabot PR #111 was closed because TypeScript 6.x conflicts with `@astrojs/check`'s peer dependency (`^5.0.0`). This PR manually updates only the textlint packages.

## Test plan
- [x] `npm run lint` — 0 errors
- [x] `npm run typecheck` — 0 errors
- [x] `npm run test` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)