### PR TITLE
perf(infra): enable CPU throttling on Cloud Run services

### DIFF
--- a/infra/stacks/dev.go
+++ b/infra/stacks/dev.go
@@ -44,6 +44,9 @@ func Dev(ctx *pulumi.Context) error {
 				Resources: &cloudrunv2.ServiceTemplateContainerResourcesArgs{
 					// Temporarily boost CPU during cold start to reduce startup latency
 					StartupCpuBoost: pulumi.Bool(true),
+					// Only bill vCPU/memory while a request is being served.
+					// Runtime is nginx serving static files — no background work.
+					CpuIdle: pulumi.Bool(true),
 				},
 			},
 		},

--- a/infra/stacks/prod.go
+++ b/infra/stacks/prod.go
@@ -41,6 +41,9 @@ func Prod(ctx *pulumi.Context) error {
 				Resources: &cloudrunv2.ServiceTemplateContainerResourcesArgs{
 					// Temporarily boost CPU during cold start to reduce startup latency
 					StartupCpuBoost: pulumi.Bool(true),
+					// Only bill vCPU/memory while a request is being served.
+					// Runtime is nginx serving static files — no background work.
+					CpuIdle: pulumi.Bool(true),
 				},
 			},
 		},


### PR DESCRIPTION
## Summary
- Add `CpuIdle: pulumi.Bool(true)` to `koborin-ai-web-prod` and `koborin-ai-web-dev` Cloud Run services
- Switches from "Always allocated CPU" (the Cloud Run V2 API default) to "CPU only during request processing"

## Why

Billing investigation showed Cloud Run was costing **~¥5,800/month out of ~¥8,800 total** (66% of the whole GCP bill).

Checking the live services with `gcloud run services describe`, both had:

```
run.googleapis.com/cpu-throttling: 'false'
```

...which means vCPU/memory were being billed for the entire time an instance was alive, not just while handling a request. Pulumi never set `CpuIdle` explicitly, so the Cloud Run V2 API default (`cpu_idle=false`) was applied. Console UI defaults to `true`, so this is a well-known foot-gun when provisioning Cloud Run V2 through IaC.

The runtime is nginx serving pre-built Astro static files (see `app/Dockerfile`). No Node.js server, no background work, no SSE/WebSocket. Always-allocated CPU has **zero upside** for this workload and significant downside — each instance sits idle between requests (extended by clawers/bot traffic) while vCPU + memory stay billed.

## Expected impact
- **Cloud Run**: ~¥5,800/month → a few hundred yen (request-time billing only)
- **Total GCP**: ~¥8,800/month → ~¥3,000/month (the remainder is mostly the HTTPS Load Balancer forwarding rule fixed fee)

🤖 Generated with [Claude Code](https://claude.com/claude-code)