### PR TITLE
Rename repo path to koborin-ai/site with OR-conditioned WIF

### DIFF
--- a/.cursor/commands/migrate-cdktf-to-pulumi.md
+++ b/.cursor/commands/migrate-cdktf-to-pulumi.md
@@ -216,7 +216,7 @@ pulumi import gcp:serviceaccount/account:Account github-actions-sa \
 
 # Service Account IAM
 pulumi import gcp:serviceaccount/iAMMember:IAMMember github-wif-user \
-  "projects/${PROJECT_ID}/serviceAccounts/github-actions-service@${PROJECT_ID}.iam.gserviceaccount.com roles/iam.workloadIdentityUser principal://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/github-actions-pool/subject/nozomi-koborinai/koborin-ai" --yes
+  "projects/${PROJECT_ID}/serviceAccounts/github-actions-service@${PROJECT_ID}.iam.gserviceaccount.com roles/iam.workloadIdentityUser principal://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/github-actions-pool/subject/koborin-ai/site" --yes
 
 # Project IAM Roles (loop)
 SA_EMAIL="github-actions-service@${PROJECT_ID}.iam.gserviceaccount.com"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,7 +280,7 @@ Examples:
   - Pool ID: `github-actions-pool`
   - Provider ID: `actions-firebase-provider`
   - Service account created in `shared` stack (`github-actions-service@<project>.iam.gserviceaccount.com`).
-  - Principal string: `principal://iam.googleapis.com/projects/<PROJECT_NUMBER>/locations/global/workloadIdentityPools/github-actions-pool/subject/nozomi-koborinai/koborin-ai`.
+  - Principal string: `principal://iam.googleapis.com/projects/<PROJECT_NUMBER>/locations/global/workloadIdentityPools/github-actions-pool/subject/koborin-ai/site`.
 
 ## Release Process
 

--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ cd infra && go build ./...
   - Pool: `github-actions-pool`.
   - Provider: `actions-firebase-provider` (OIDC issuer: `https://token.actions.githubusercontent.com`).
   - Service Account: `github-actions-service@{project}.iam.gserviceaccount.com`.
-  - IAM binding: Subject-based binding for repository `nozomi-koborinai/koborin-ai`.
+  - IAM binding: Subject-based binding for repository `koborin-ai/site`.
   - Project IAM roles (Artifact Registry, Run, Compute, IAM, etc.) granted to the Pulumi SA.
 - **DNS**: Records live in Cloudflare and are managed manually (A records point to the LB IP).
 

--- a/app/src/components/Giscus.astro
+++ b/app/src/components/Giscus.astro
@@ -9,7 +9,7 @@
  */
 
 // Hardcoded values (public info)
-const repo = 'nozomi-koborinai/koborin-ai';
+const repo = 'koborin-ai/site';
 const category = 'Comments';
 
 // Get IDs from environment variables (set via GitHub Secrets in CI)

--- a/app/src/content/docs/ja/tech/koborin-ai-architecture.mdx
+++ b/app/src/content/docs/ja/tech/koborin-ai-architecture.mdx
@@ -477,7 +477,7 @@ GitHub Actions の OIDC トークンを使って Google Cloud に認証し、事
 
 ### Stack 別インフラ実装
 
-<RichLinkCard href="https://github.com/nozomi-koborinai/koborin-ai/tree/main/infra" title="koborin-ai/infra at main · nozomi-koborinai/koborin-ai" description="Pulumi Go stacks for koborin.ai infrastructure (shared, dev, prod)." />
+<RichLinkCard href="https://github.com/koborin-ai/site/tree/main/infra" title="site/infra at main · koborin-ai/site" description="Pulumi Go stacks for koborin.ai infrastructure (shared, dev, prod)." />
 
 #### infra/stacks/shared.go
 
@@ -771,7 +771,7 @@ func Shared(ctx *pulumi.Context) error {
 		WorkloadIdentityPoolProviderId: pulumi.String("actions-firebase-provider"),
 		DisplayName:                    pulumi.String("github-actions-provider"),
 		Description:                    pulumi.String("GitHub Actions OIDC provider"),
-		AttributeCondition: pulumi.String(`assertion.repository_owner == "nozomi-koborinai"`),
+		AttributeCondition: pulumi.String(`assertion.repository_owner == "koborin-ai"`),
 		AttributeMapping: pulumi.StringMap{
 			"google.subject":             pulumi.String("assertion.repository"),
 			"attribute.repository_owner": pulumi.String("assertion.repository_owner"),
@@ -798,7 +798,7 @@ func Shared(ctx *pulumi.Context) error {
 		ServiceAccountId: githubActionsSA.Name,
 		Role:             pulumi.String("roles/iam.workloadIdentityUser"),
 		Member: pulumi.Sprintf(
-			"principal://iam.googleapis.com/projects/%s/locations/global/workloadIdentityPools/%s/subject/nozomi-koborinai/koborin-ai",
+			"principal://iam.googleapis.com/projects/%s/locations/global/workloadIdentityPools/%s/subject/koborin-ai/site",
 			projectNumber,
 			workloadIdentityPool.WorkloadIdentityPoolId,
 		),
@@ -1010,7 +1010,7 @@ func Prod(ctx *pulumi.Context) error {
 
 ### App 実装
 
-<RichLinkCard href="https://github.com/nozomi-koborinai/koborin-ai/tree/main/app" title="koborin-ai/app at main · nozomi-koborinai/koborin-ai" description="Astro + Starlight application for koborin.ai." />
+<RichLinkCard href="https://github.com/koborin-ai/site/tree/main/app" title="site/app at main · koborin-ai/site" description="Astro + Starlight application for koborin.ai." />
 
 #### app/astro.config.mjs
 
@@ -1192,4 +1192,4 @@ http {
 
 ## koborin.ai 開発リポジトリ
 
-<RichLinkCard href="https://github.com/nozomi-koborinai/koborin-ai" title="koborin-ai" description="🪴 A repository for building personal homepages and technical garden on GCP" />
+<RichLinkCard href="https://github.com/koborin-ai/site" title="site" description="🪴 A repository for building personal homepages and technical garden on GCP" />

--- a/app/src/content/docs/ja/tech/plugin-marketplace.mdx
+++ b/app/src/content/docs/ja/tech/plugin-marketplace.mdx
@@ -33,11 +33,11 @@ koborin.ai が Claude Code の Plugin Marketplace として機能するように
 
 ```bash
 # ターミナルから
-claude plugin marketplace add nozomi-koborinai/koborin-ai
+claude plugin marketplace add koborin-ai/site
 claude plugin install mermaid-diagram@koborinai-plugins
 
 # Claude Code 内から
-/plugin marketplace add nozomi-koborinai/koborin-ai
+/plugin marketplace add koborin-ai/site
 /plugin install mermaid-diagram@koborinai-plugins
 ```
 
@@ -75,7 +75,7 @@ flowchart LR
         DOTFILES["nozomi-koborinai/dotfiles\nskills/ + public-skills.yml"]
     end
     subgraph PUBLIC["Public Repository"]
-        KOBORINAI["nozomi-koborinai/koborin-ai\nplugins/ + marketplace.json"]
+        KOBORINAI["koborin-ai/site\nplugins/ + marketplace.json"]
     end
     DOTFILES -->|GitHub Actions| KOBORINAI
     KOBORINAI -->|cc-plugin-catalog| SITE["koborin.ai/plugins/"]

--- a/app/src/content/docs/tech/koborin-ai-architecture.mdx
+++ b/app/src/content/docs/tech/koborin-ai-architecture.mdx
@@ -470,7 +470,7 @@ From here, I'll introduce specific implementation details. Those interested can 
 
 ### Stack-Based Infrastructure Implementation
 
-<RichLinkCard href="https://github.com/nozomi-koborinai/koborin-ai/tree/main/infra" title="koborin-ai/infra at main · nozomi-koborinai/koborin-ai" description="Pulumi Go stacks for koborin.ai infrastructure (shared, dev, prod)." />
+<RichLinkCard href="https://github.com/koborin-ai/site/tree/main/infra" title="site/infra at main · koborin-ai/site" description="Pulumi Go stacks for koborin.ai infrastructure (shared, dev, prod)." />
 
 #### infra/stacks/shared.go
 
@@ -742,7 +742,7 @@ func Shared(ctx *pulumi.Context) error {
 		WorkloadIdentityPoolProviderId: pulumi.String("actions-firebase-provider"),
 		DisplayName:                    pulumi.String("github-actions-provider"),
 		Description:                    pulumi.String("GitHub Actions OIDC provider"),
-		AttributeCondition: pulumi.String(`assertion.repository_owner == "nozomi-koborinai"`),
+		AttributeCondition: pulumi.String(`assertion.repository_owner == "koborin-ai"`),
 		AttributeMapping: pulumi.StringMap{
 			"google.subject":             pulumi.String("assertion.repository"),
 			"attribute.repository_owner": pulumi.String("assertion.repository_owner"),
@@ -769,7 +769,7 @@ func Shared(ctx *pulumi.Context) error {
 		ServiceAccountId: githubActionsSA.Name,
 		Role:             pulumi.String("roles/iam.workloadIdentityUser"),
 		Member: pulumi.Sprintf(
-			"principal://iam.googleapis.com/projects/%s/locations/global/workloadIdentityPools/%s/subject/nozomi-koborinai/koborin-ai",
+			"principal://iam.googleapis.com/projects/%s/locations/global/workloadIdentityPools/%s/subject/koborin-ai/site",
 			projectNumber,
 			workloadIdentityPool.WorkloadIdentityPoolId,
 		),
@@ -981,7 +981,7 @@ func Prod(ctx *pulumi.Context) error {
 
 ### App Implementation
 
-<RichLinkCard href="https://github.com/nozomi-koborinai/koborin-ai/tree/main/app" title="koborin-ai/app at main · nozomi-koborinai/koborin-ai" description="Astro + Starlight application for koborin.ai." />
+<RichLinkCard href="https://github.com/koborin-ai/site/tree/main/app" title="site/app at main · koborin-ai/site" description="Astro + Starlight application for koborin.ai." />
 
 #### app/astro.config.mjs
 
@@ -1163,4 +1163,4 @@ http {
 
 ## Source Code
 
-<RichLinkCard href="https://github.com/nozomi-koborinai/koborin-ai" title="koborin-ai" description="🪴 A repository for building personal homepages and technical garden on GCP" />
+<RichLinkCard href="https://github.com/koborin-ai/site" title="site" description="🪴 A repository for building personal homepages and technical garden on GCP" />

--- a/app/src/content/docs/tech/plugin-marketplace.mdx
+++ b/app/src/content/docs/tech/plugin-marketplace.mdx
@@ -33,11 +33,11 @@ Anyone can install published skills with the following commands:
 
 ```bash
 # From the terminal
-claude plugin marketplace add nozomi-koborinai/koborin-ai
+claude plugin marketplace add koborin-ai/site
 claude plugin install mermaid-diagram@koborinai-plugins
 
 # From within Claude Code
-/plugin marketplace add nozomi-koborinai/koborin-ai
+/plugin marketplace add koborin-ai/site
 /plugin install mermaid-diagram@koborinai-plugins
 ```
 
@@ -75,7 +75,7 @@ flowchart LR
         DOTFILES["nozomi-koborinai/dotfiles\nskills/ + public-skills.yml"]
     end
     subgraph PUBLIC["Public Repository"]
-        KOBORINAI["nozomi-koborinai/koborin-ai\nplugins/ + marketplace.json"]
+        KOBORINAI["koborin-ai/site\nplugins/ + marketplace.json"]
     end
     DOTFILES -->|GitHub Actions| KOBORINAI
     KOBORINAI -->|cc-plugin-catalog| SITE["koborin.ai/plugins/"]

--- a/infra/go.mod
+++ b/infra/go.mod
@@ -1,4 +1,4 @@
-module github.com/nozomi-koborinai/koborin-ai/infra-go
+module github.com/koborin-ai/site/infra-go
 
 go 1.25.8
 

--- a/infra/main.go
+++ b/infra/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/nozomi-koborinai/koborin-ai/infra-go/stacks"
+	"github.com/koborin-ai/site/infra-go/stacks"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 

--- a/infra/stacks/shared.go
+++ b/infra/stacks/shared.go
@@ -286,8 +286,9 @@ func Shared(ctx *pulumi.Context) error {
 		WorkloadIdentityPoolProviderId: pulumi.String("actions-firebase-provider"),
 		DisplayName:                    pulumi.String("github-actions-provider"),
 		Description:                    pulumi.String("GitHub Actions OIDC provider"),
-		// Only allow workflows from repositories owned by nozomi-koborinai
-		AttributeCondition: pulumi.String(`assertion.repository_owner == "nozomi-koborinai"`),
+		// Allow both old (nozomi-koborinai, pre-migration) and new (koborin-ai) owners during rename+transfer.
+		// Narrow back to `koborin-ai` only after migration is fully verified.
+		AttributeCondition: pulumi.String(`assertion.repository_owner == "nozomi-koborinai" || assertion.repository_owner == "koborin-ai"`),
 		AttributeMapping: pulumi.StringMap{
 			"google.subject":             pulumi.String("assertion.repository"),
 			"attribute.repository_owner": pulumi.String("assertion.repository_owner"),
@@ -311,12 +312,27 @@ func Shared(ctx *pulumi.Context) error {
 		return err
 	}
 
-	// Allow Workload Identity Pool to impersonate the service account
+	// Allow Workload Identity Pool to impersonate the service account.
+	// Binding for the old repo path (nozomi-koborinai/koborin-ai); delete after migration is verified.
 	_, err = serviceaccount.NewIAMMember(ctx, "github-wif-user", &serviceaccount.IAMMemberArgs{
 		ServiceAccountId: githubActionsSA.Name,
 		Role:             pulumi.String("roles/iam.workloadIdentityUser"),
 		Member: pulumi.Sprintf(
 			"principal://iam.googleapis.com/projects/%s/locations/global/workloadIdentityPools/%s/subject/nozomi-koborinai/koborin-ai",
+			projectNumber,
+			workloadIdentityPool.WorkloadIdentityPoolId,
+		),
+	})
+	if err != nil {
+		return err
+	}
+
+	// Binding for the new repo path (koborin-ai/site) after rename+transfer.
+	_, err = serviceaccount.NewIAMMember(ctx, "github-wif-user-new", &serviceaccount.IAMMemberArgs{
+		ServiceAccountId: githubActionsSA.Name,
+		Role:             pulumi.String("roles/iam.workloadIdentityUser"),
+		Member: pulumi.Sprintf(
+			"principal://iam.googleapis.com/projects/%s/locations/global/workloadIdentityPools/%s/subject/koborin-ai/site",
 			projectNumber,
 			workloadIdentityPool.WorkloadIdentityPoolId,
 		),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "koborin-ai",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/plugins/agent-team-fullstack/.claude-plugin/plugin.json
+++ b/plugins/agent-team-fullstack/.claude-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "Nozomi Koborinai"
   },
-  "repository": "https://github.com/nozomi-koborinai/koborin-ai",
+  "repository": "https://github.com/koborin-ai/site",
   "license": "MIT",
   "skills": "./skills/"
 }

--- a/plugins/mermaid-diagram/.claude-plugin/plugin.json
+++ b/plugins/mermaid-diagram/.claude-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "Nozomi Koborinai"
   },
-  "repository": "https://github.com/nozomi-koborinai/koborin-ai",
+  "repository": "https://github.com/koborin-ai/site",
   "license": "MIT",
   "skills": "./skills/"
 }


### PR DESCRIPTION
## Summary

- Phase 1 of migrating this repo from `nozomi-koborinai/koborin-ai` to `koborin-ai/site` under a new `koborin-ai` GitHub organization (primary driver: Blacksmith Actions runners require an org).
- Updates Go module path, plugin `repository` URLs, the Giscus repo target, and every doc that references the old path.
- Stages an **OR-conditioned WIF** in `infra/stacks/shared.go` so both the old (`nozomi-koborinai`) and new (`koborin-ai`) owners / subjects are accepted during the rename + transfer window. This eliminates the auth-failure window that a direct switch would cause.
- Removes obsolete root `package-lock.json` (no matching `package.json`; the real app lockfile lives under `app/`).

## Migration sequence after merge

1. Merge this PR.
2. Manually dispatch `release-infra.yml` (shared stack) → Pulumi applies the OR state to GCP WIF. Auth still uses the old subject, which is still allowed.
3. On GitHub: create the `koborin-ai` org, rename the repo `koborin-ai` → `site`, transfer to `koborin-ai`. Actions continue to work because the new subject is now also allowed.
4. Update local remote, cut an `app-v*` tag → `app-release.yml` redeploys the site with the new Giscus / plugin URLs baked in.
5. Follow-up PR (Phase 3) narrows `AttributeCondition` back to `koborin-ai` only and removes the legacy `github-wif-user` IAMMember.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nozomi-koborinai/codesmith/koborin-ai/pr/117"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->