### PR TITLE
Narrow WIF to koborin-ai/site only (migration cleanup)

### DIFF
--- a/infra/stacks/shared.go
+++ b/infra/stacks/shared.go
@@ -286,9 +286,8 @@ func Shared(ctx *pulumi.Context) error {
 		WorkloadIdentityPoolProviderId: pulumi.String("actions-firebase-provider"),
 		DisplayName:                    pulumi.String("github-actions-provider"),
 		Description:                    pulumi.String("GitHub Actions OIDC provider"),
-		// Allow both old (nozomi-koborinai, pre-migration) and new (koborin-ai) owners during rename+transfer.
-		// Narrow back to `koborin-ai` only after migration is fully verified.
-		AttributeCondition: pulumi.String(`assertion.repository_owner == "nozomi-koborinai" || assertion.repository_owner == "koborin-ai"`),
+		// Only allow workflows from repositories owned by koborin-ai
+		AttributeCondition: pulumi.String(`assertion.repository_owner == "koborin-ai"`),
 		AttributeMapping: pulumi.StringMap{
 			"google.subject":             pulumi.String("assertion.repository"),
 			"attribute.repository_owner": pulumi.String("assertion.repository_owner"),
@@ -312,22 +311,7 @@ func Shared(ctx *pulumi.Context) error {
 		return err
 	}
 
-	// Allow Workload Identity Pool to impersonate the service account.
-	// Binding for the old repo path (nozomi-koborinai/koborin-ai); delete after migration is verified.
-	_, err = serviceaccount.NewIAMMember(ctx, "github-wif-user", &serviceaccount.IAMMemberArgs{
-		ServiceAccountId: githubActionsSA.Name,
-		Role:             pulumi.String("roles/iam.workloadIdentityUser"),
-		Member: pulumi.Sprintf(
-			"principal://iam.googleapis.com/projects/%s/locations/global/workloadIdentityPools/%s/subject/nozomi-koborinai/koborin-ai",
-			projectNumber,
-			workloadIdentityPool.WorkloadIdentityPoolId,
-		),
-	})
-	if err != nil {
-		return err
-	}
-
-	// Binding for the new repo path (koborin-ai/site) after rename+transfer.
+	// Allow Workload Identity Pool to impersonate the service account
 	_, err = serviceaccount.NewIAMMember(ctx, "github-wif-user-new", &serviceaccount.IAMMemberArgs{
 		ServiceAccountId: githubActionsSA.Name,
 		Role:             pulumi.String("roles/iam.workloadIdentityUser"),


### PR DESCRIPTION
## Summary

Phase 3 of the `nozomi-koborinai/koborin-ai` → `koborin-ai/site` migration. Narrows the Workload Identity Federation configuration back to the new path only, now that the rename + transfer + redeploy have been verified.

- `AttributeCondition`: drop the OR branch; allow `koborin-ai` owner only.
- Remove the `github-wif-user` IAMMember whose subject was `nozomi-koborinai/koborin-ai`.
- Clean up migration-related comments.

The `github-wif-user-new` IAMMember (with the `koborin-ai/site` subject) is kept as-is so the active binding is never torn down; renaming the resource back to `github-wif-user` can happen in a follow-up via `pulumi state rename` if desired.

Follows #117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)