### PR TITLE
fix(ui): improve content width, header spacing, and mobile menu layout

### DIFF
--- a/app/src/styles/custom.css
+++ b/app/src/styles/custom.css
@@ -177,7 +177,13 @@
   }
 }
 
-/* Increase social icon size in Starlight header */
+/* Increase social icon size and spacing in Starlight header */
+.right-group {
+  gap: 1.25rem;
+}
+.social-icons {
+  gap: 1.25rem;
+}
 .social-icons a {
   font-size: 1.25rem;
 }
@@ -343,10 +349,13 @@
    Desktop content width adjustment - reduce right margin excess
    ========================================================================== */
 
-/* Widen content area on desktop with sidebar to reduce excessive right gutter */
+/* Adjust content width and center it between sidebars */
 @media (min-width: 72rem) {
   html[data-has-sidebar] {
-    --sl-content-width: clamp(45rem, 55vw, 60rem);
+    --sl-content-width: clamp(45rem, 55vw, 50rem);
+  }
+  [data-has-sidebar][data-has-toc] .main-pane {
+    --sl-content-margin-inline: auto;
   }
 }
 
@@ -490,7 +499,7 @@
     background: var(--color-bg-primary, #0a0a0f) !important;
   }
 
-  /* Social icons in mobile sidebar */
+  /* Social icons in mobile sidebar - full width row */
   .sidebar .social-icons,
   .mobile-preferences .social-icons {
     display: flex !important;
@@ -499,6 +508,7 @@
     padding: var(--space-lg, 1.5rem) 0 !important;
     border-top: 1px solid var(--color-border, #e5e7eb) !important;
     margin-top: var(--space-lg, 1.5rem) !important;
+    width: 100% !important;
   }
   
   [data-theme="dark"] .sidebar .social-icons,
@@ -538,10 +548,35 @@
     background: var(--color-bg-tertiary, #1a1a25) !important;
   }
   
-  /* Theme selector in mobile sidebar */
+  /* Theme and language selectors in mobile sidebar - same row, centered */
+  .mobile-preferences {
+    justify-content: center !important;
+    column-gap: 1.5rem !important;
+    align-items: center !important;
+  }
   .mobile-preferences starlight-theme-select,
-  .sidebar starlight-theme-select {
+  .mobile-preferences starlight-lang-select,
+  .sidebar starlight-theme-select,
+  .sidebar starlight-lang-select {
     margin-top: var(--space-md, 1rem) !important;
+  }
+  /* Match LanguageSelect style to custom ThemeSelect container */
+  .mobile-preferences starlight-lang-select label {
+    background: var(--sl-color-bg-nav, #16161f) !important;
+    border: 1px solid var(--sl-color-hairline, #27272a) !important;
+    border-radius: 0.5rem !important;
+    padding: 0.375rem 0.5rem !important;
+    font-size: 0.875rem !important;
+    color: var(--sl-color-gray-2, #a1a1aa) !important;
+    transition: all 150ms ease !important;
+  }
+  .mobile-preferences starlight-lang-select select {
+    padding-block: 0 !important;
+    margin-inline: 0 !important;
+    width: auto !important;
+  }
+  .mobile-preferences starlight-lang-select .label-icon {
+    inset-inline-start: 0.5rem !important;
   }
 }
 


### PR DESCRIPTION
## Summary
- Reduce max content width from 60rem to 50rem for better readability in both English and Japanese
- Center content between sidebars to balance left/right margins
- Increase header social icon gap from 1rem to 1.25rem to reduce crowding
- Fix mobile menu layout: social icons on full-width row, theme/language selectors centered side-by-side
- Match LanguageSelect container style to custom ThemeSelect in mobile menu

## Test plan
- [x] Verify content width and left/right margin balance on desktop
- [x] Verify header icon spacing is appropriate
- [x] Verify Auto/English selectors in mobile hamburger menu have matching height and style
- [x] Check for no visual regressions in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)