### PR TITLE
docs: add release-notes cards to contextlint v0.9 article

### DIFF
--- a/app/src/content/docs/ja/tech/contextlint-lsp-and-editor-integration.mdx
+++ b/app/src/content/docs/ja/tech/contextlint-lsp-and-editor-integration.mdx
@@ -30,6 +30,12 @@ import quickfixAppliedImage from '../../../../assets/tech/contextlint-lsp-and-ed
 
 本記事は、その v0.9 のアップデートに焦点を当てた続編です。
 
+<RichLinkCard
+  href="https://github.com/nozomi-koborinai/contextlint/releases/tag/v0.9.0"
+  title="Release v0.9.0 · nozomi-koborinai/contextlint"
+  description="contextlint v0.9.0 のリリースノート。LSP サーバー、VS Code 拡張、Code Actions、ワークスペース全体の lint、診断位置の精度改善などの詳細"
+/>
+
 ## フィードバックの三層構造
 
 v0.9 までの contextlint は、フィードバックのレイヤーが 2 つでした。
@@ -79,13 +85,19 @@ npm install -D @contextlint/lsp-server
 
 一番手軽な入り口は、リリースごとに VSIX として配布されている VS Code 拡張です。
 
-1. [GitHub リリース](https://github.com/nozomi-koborinai/contextlint/releases) から `contextlint-vscode-VERSION.vsix` をダウンロード
+1. GitHub リリースから `contextlint-vscode-VERSION.vsix` をダウンロード
 2. 拡張機能ビューの **Views and More Actions… → Install from VSIX…** で先ほどの `.vsix` を選択
 3. もしくはコマンドラインから:
 
 ```bash
 code --install-extension contextlint-vscode-VERSION.vsix
 ```
+
+<RichLinkCard
+  href="https://github.com/nozomi-koborinai/contextlint/releases"
+  title="Releases · nozomi-koborinai/contextlint"
+  description="contextlint の全リリース一覧。各リリースに VSIX ファイルが添付されています"
+/>
 
 拡張は Markdown ファイルを開いたタイミングで起動し、最寄りの `contextlint.config.json` を見つけて `@contextlint/lsp-server` を自動的に立ち上げます。設定ファイルさえあれば、追加の操作は不要です。
 

--- a/app/src/content/docs/tech/contextlint-lsp-and-editor-integration.mdx
+++ b/app/src/content/docs/tech/contextlint-lsp-and-editor-integration.mdx
@@ -30,6 +30,12 @@ In **v0.9**, the project crossed a different kind of line: contextlint now ships
 
 This is a follow-up focused on that v0.9 step.
 
+<RichLinkCard
+  href="https://github.com/nozomi-koborinai/contextlint/releases/tag/v0.9.0"
+  title="Release v0.9.0 · nozomi-koborinai/contextlint"
+  description="Full release notes for contextlint v0.9.0 — LSP server, VS Code extension, Code Actions, workspace-wide lint, and diagnostic-line accuracy fixes."
+/>
+
 ## Three layers of feedback
 
 Before v0.9, contextlint covered two layers of feedback:
@@ -76,13 +82,19 @@ In other words, the LSP isn't a stripped-down subset of the CLI — it runs the 
 
 The simplest way in is the bundled VS Code extension, distributed as a VSIX on every release.
 
-1. Grab `contextlint-vscode-VERSION.vsix` from the [latest GitHub Release](https://github.com/nozomi-koborinai/contextlint/releases).
+1. Grab `contextlint-vscode-VERSION.vsix` from the latest GitHub release.
 2. From the Extensions view: **Views and More Actions… → Install from VSIX…** and pick the file.
 3. Or from the command line:
 
 ```bash
 code --install-extension contextlint-vscode-VERSION.vsix
 ```
+
+<RichLinkCard
+  href="https://github.com/nozomi-koborinai/contextlint/releases"
+  title="Releases · nozomi-koborinai/contextlint"
+  description="All contextlint releases — each one ships a VSIX asset for direct download."
+/>
 
 The extension activates on Markdown files, finds the nearest `contextlint.config.json`, and starts `@contextlint/lsp-server` automatically. No further setup needed.
 


### PR DESCRIPTION
## Summary
Mirror the same cards-related edits that were merged into the Zenn version of this article (https://github.com/nozomi-koborinai/zenn/pull/41).

- Add a v0.9.0 release-notes card right after the intro so readers can drill into the source release for full detail.
- Convert the inline "GitHub Releases" link in the VS Code section into a card placed after the install steps, making the download destination more visually anchored.
- Apply both changes to the en + ja versions of the article.

## Test plan
- [x] `npm run build` — 25 pages built
- [ ] Visually check both articles in a browser to confirm the new cards render

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/koborin-ai/codesmith/site/pr/129"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->