### PR TITLE
ci(dependabot): ignore TypeScript major version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
         dependency-type: development
       production-dependencies:
         dependency-type: production
+    ignore:
+      - dependency-name: typescript
+        update-types:
+          - version-update:semver-major
 
   - package-ecosystem: gomod
     directory: /infra

--- a/app/src/content/docs/ja/life/acknowledging-aging.mdx
+++ b/app/src/content/docs/ja/life/acknowledging-aging.mdx
@@ -3,6 +3,7 @@ title: 老いていく自分を認める
 description: 変わっていく自分に気づいた時、どう向き合うか。
 publishedAt: 2026-02-22
 ogImage: /og/acknowledging-aging.png
+draft: true
 ---
 
 <img src="/og/acknowledging-aging.png" alt="老いていく自分を認める" width="1024" height="540" fetchpriority="high" style="width: 100%; height: auto;" />

--- a/app/src/content/docs/life/acknowledging-aging.mdx
+++ b/app/src/content/docs/life/acknowledging-aging.mdx
@@ -3,6 +3,7 @@ title: Acknowledging the Process of Aging
 description: What do you do when you notice yourself changing?
 publishedAt: 2026-02-22
 ogImage: /og/acknowledging-aging.png
+draft: true
 ---
 
 <img src="/og/acknowledging-aging.png" alt="Acknowledging Aging" width="1024" height="540" fetchpriority="high" style="width: 100%; height: auto;" />

--- a/app/src/sidebar.ts
+++ b/app/src/sidebar.ts
@@ -45,11 +45,6 @@ export const sidebar = [
     label: "Life",
     items: [
       {
-        label: "Acknowledging Aging",
-        translations: { ja: "老いを認めるということ" },
-        slug: "life/acknowledging-aging",
-      },
-      {
         label: "Everything Has Meaning",
         translations: { ja: "全てのことに意味がある" },
         slug: "life/everything-has-meaning",


### PR DESCRIPTION
Group bumps from Dependabot were pulling in TS 5 → 6 alongside
unrelated dev tooling, breaking CI on PR #134. Ignore TypeScript
majors so the dev-dependencies group stays mergeable; TS 6 will
be evaluated separately.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/koborin-ai/codesmith/site/pr/137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->