### PR TITLE
fix(header): close nav-logo anchor to restore search dialog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ coverage/
 .nyc_output/
 test-results/
 playwright-report/
+.playwright-mcp/
 
 # IDE / Editors
 .vscode/

--- a/app/src/components/SiteHeader.astro
+++ b/app/src/components/SiteHeader.astro
@@ -24,7 +24,8 @@ const homeHref = isJapanese ? '/ja/' : '/';
     <a href={homeHref} class="nav-logo" aria-label="koborin.ai home">
       <Image src={headerLogoDark} alt="koborin.ai" height={144} class="logo-dark" loading="eager" />
       <Image src={headerLogoLight} alt="koborin.ai" height={144} class="logo-light" loading="eager" />
-    
+    </a>
+
     <div class="nav-actions">
       <div class="nav-search">
         <Search {...props} />


### PR DESCRIPTION
## Summary

The `<a class=\"nav-logo\">` in `SiteHeader.astro` was missing its closing tag. The HTML5 adoption agency algorithm responded by re-opening the anchor inside `<div class=\"nav-actions\">`, wrapping the search button (and every other action) in a duplicated `<a href=\"/\">`. Two visible problems followed:

- Clicking the search button bubbled up to the duplicated anchor and navigated to `/`, so the dialog only flashed before the page unloaded.
- The malformed DOM prevented `.nav-search { flex: 1; max-width: 400px }` from taking effect on desktop, squeezing the search box to ~130px.

Closing the anchor properly fixes both. No layout-side changes were needed: the search box expands to ~400px on its own once the structure is healed.

Also adds `.playwright-mcp/` to `.gitignore` so the MCP browser tool's cache directory does not leak into commits.

## Verification

Verified on `npm run preview` build with Playwright:

| Metric | Before | After |
| --- | --- | --- |
| `searchButtonWidth` | 130px | 352px |
| `navSearchWidth` | — | 400px (max-width hit) |
| `searchBtn.closest('a')` | `nav-logo` (bug) | `null` |
| Click on search button | navigates to `/` | opens dialog, stays open |

`npm run lint` and `npm run build` both succeed.

## Test plan

- [x] Click the search button on desktop — dialog opens and stays open.
- [x] Search box visually fills its allotted ~400px space.
- [x] Cmd/Ctrl+K still toggles the dialog.
- [x] Mobile header still works (search hidden, mobile toggle visible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/koborin-ai/codesmith/site/pr/142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->