### PR TITLE
fix(home): restore card image display width (160px)

### DIFF
--- a/app/src/content/docs/index.mdx
+++ b/app/src/content/docs/index.mdx
@@ -47,7 +47,7 @@ Currently working across cloud architecture, pre-sales, and team leadership at a
 
 <div style="display: flex; gap: 1.5rem; align-items: flex-start; flex-wrap: wrap; margin: 1rem 0;">
 <a href="https://www.amazon.com/dp/B0G4HKJRPB">
-<SiteImage src={bookCover} alt="Mastering Genkit: Go Edition Cover" variant="card" style="border-radius: 6px; box-shadow: 0 4px 12px rgba(0,0,0,0.15);" />
+<SiteImage src={bookCover} alt="Mastering Genkit: Go Edition Cover" variant="card" style="width: 160px; border-radius: 6px; box-shadow: 0 4px 12px rgba(0,0,0,0.15);" />
 </a>
 <div style="flex: 1; min-width: 200px;">
 
@@ -67,7 +67,7 @@ Unlock the full potential of Genkit and Go—explore the journey from fundamenta
 
 <div style="display: flex; gap: 1.5rem; align-items: flex-start; flex-wrap: wrap; margin: 1.5rem 0;">
 <a href="https://contextlint.dev/">
-<SiteImage src={contextlintOg} alt="contextlint OG image" variant="card" style="border-radius: 6px; box-shadow: 0 4px 12px rgba(0,0,0,0.15);" />
+<SiteImage src={contextlintOg} alt="contextlint OG image" variant="card" style="width: 160px; border-radius: 6px; box-shadow: 0 4px 12px rgba(0,0,0,0.15);" />
 </a>
 <div style="flex: 1; min-width: 200px;">
 
@@ -81,7 +81,7 @@ A semantic linter for AI-era Markdown. Verifies cross-references, required secti
 
 <div style="display: flex; gap: 1.5rem; align-items: flex-start; flex-wrap: wrap; margin: 1.5rem 0;">
 <a href="https://github.com/nozomi-koborinai/ableton-osc-mcp">
-<SiteImage src={abletonOscMcpKey} alt="Ableton OSC MCP Server key visual" variant="card" style="border-radius: 6px; box-shadow: 0 4px 12px rgba(0,0,0,0.15);" />
+<SiteImage src={abletonOscMcpKey} alt="Ableton OSC MCP Server key visual" variant="card" style="width: 160px; border-radius: 6px; box-shadow: 0 4px 12px rgba(0,0,0,0.15);" />
 </a>
 <div style="flex: 1; min-width: 200px;">
 

--- a/app/src/content/docs/ja/index.mdx
+++ b/app/src/content/docs/ja/index.mdx
@@ -49,7 +49,7 @@ Built by [@nozomi-koborinai](https://github.com/nozomi-koborinai).
 
 <div style="display: flex; gap: 1.5rem; align-items: flex-start; flex-wrap: wrap; margin: 1rem 0;">
 <a href="https://www.amazon.com/dp/B0G4HKJRPB">
-<SiteImage src={bookCover} alt="Mastering Genkit: Go Edition 表紙" variant="card" style="border-radius: 6px; box-shadow: 0 4px 12px rgba(0,0,0,0.15);" />
+<SiteImage src={bookCover} alt="Mastering Genkit: Go Edition 表紙" variant="card" style="width: 160px; border-radius: 6px; box-shadow: 0 4px 12px rgba(0,0,0,0.15);" />
 </a>
 <div style="flex: 1; min-width: 200px;">
 
@@ -69,7 +69,7 @@ Genkit と Go の可能性を最大限に引き出し、初歩から高度な AI
 
 <div style="display: flex; gap: 1.5rem; align-items: flex-start; flex-wrap: wrap; margin: 1.5rem 0;">
 <a href="https://contextlint.dev/">
-<SiteImage src={contextlintOg} alt="contextlint OG 画像" variant="card" style="border-radius: 6px; box-shadow: 0 4px 12px rgba(0,0,0,0.15);" />
+<SiteImage src={contextlintOg} alt="contextlint OG 画像" variant="card" style="width: 160px; border-radius: 6px; box-shadow: 0 4px 12px rgba(0,0,0,0.15);" />
 </a>
 <div style="flex: 1; min-width: 200px;">
 
@@ -83,7 +83,7 @@ AI 時代の Markdown のためのセマンティックリンター。エディ�
 
 <div style="display: flex; gap: 1.5rem; align-items: flex-start; flex-wrap: wrap; margin: 1.5rem 0;">
 <a href="https://github.com/nozomi-koborinai/ableton-osc-mcp">
-<SiteImage src={abletonOscMcpKey} alt="Ableton OSC MCP Server キービジュアル" variant="card" style="border-radius: 6px; box-shadow: 0 4px 12px rgba(0,0,0,0.15);" />
+<SiteImage src={abletonOscMcpKey} alt="Ableton OSC MCP Server キービジュアル" variant="card" style="width: 160px; border-radius: 6px; box-shadow: 0 4px 12px rgba(0,0,0,0.15);" />
 </a>
 <div style="flex: 1; min-width: 200px;">
 


### PR DESCRIPTION
## Summary

Hotfix for #143. Phase 3 dropped `width={160}` when migrating cards from `<Image>` to `<SiteImage variant="card">`, but the HTML `width` attribute was the only mechanism constraining the cards to 160px. Without it, the global `.sl-markdown-content img { width: 100% }` rule expanded the card images to fill their container — making them appear huge and pixelated on the home page.

This fix restores the explicit display width via inline `style` (which beats the global rule on specificity), the minimum correct change.

### Affected

- `app/src/content/docs/index.mdx` — 3 card images (Mastering Genkit / contextlint / Ableton OSC MCP)
- `app/src/content/docs/ja/index.mdx` — same 3

### Why not fix the SiteImage component itself?

The `card` variant's `widths` preset `[160, 320, 480]` is for srcset selection — the actual rendered size is a layout decision, not a component decision. Constraining the rendered width belongs at the call site (or in scoped CSS for the home page layout). A larger refactor would add a `width` prop to SiteImage, but for a one-page hotfix the inline style is the minimum change.

## Test plan

- [x] `npm run lint && typecheck && test` (astro check) — 0 errors
- [x] `npm run check-images` — passed
- [x] `astro build` — succeeds; verified `style="width: 160px; ..."` lands on the `<img>` element in `dist/index.html`
- [x] Manual visual check on deployed preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/koborin-ai/codesmith/site/pr/144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->