### PR TITLE
fix(home): hero sizing + image zoom UX (no-zoom for linked images)

### DIFF
--- a/app/src/components/ImageZoom.astro
+++ b/app/src/components/ImageZoom.astro
@@ -6,8 +6,15 @@
   import mediumZoom from 'medium-zoom';
 
   function initZoom() {
-    // Initialize medium-zoom for content images
-    mediumZoom('.sl-markdown-content img:not(.medium-zoom-image)', {
+    // Initialize medium-zoom for content images, excluding images wrapped in
+    // <a> (linked images should follow the link instead of zooming).
+    const candidates = document.querySelectorAll(
+      '.sl-markdown-content img:not(.medium-zoom-image)'
+    );
+    const zoomable = Array.from(candidates).filter(
+      (img) => !img.closest('a')
+    );
+    mediumZoom(zoomable, {
       margin: 24,
       background: 'rgba(0, 0, 0, 0.9)',
       scrollOffset: 0,
@@ -74,7 +81,7 @@
 
   // Initialize on page load
   document.addEventListener('astro:page-load', initZoom);
-  
+
   // Also run on initial load for non-SPA navigation
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', initZoom);
@@ -82,4 +89,13 @@
     initZoom();
   }
 </script>
+
+<style is:global>
+  /* medium-zoom does not set z-index; Starlight's site header has z-index 10,
+     so without this override the zoomed image is hidden behind the header. */
+  .medium-zoom-overlay,
+  .medium-zoom-image--opened {
+    z-index: 1000;
+  }
+</style>
 

--- a/app/src/components/ImageZoom.astro
+++ b/app/src/components/ImageZoom.astro
@@ -8,7 +8,7 @@
   function initZoom() {
     // Initialize medium-zoom for content images, excluding images wrapped in
     // <a> (linked images should follow the link instead of zooming).
-    const candidates = document.querySelectorAll(
+    const candidates = document.querySelectorAll<HTMLImageElement>(
       '.sl-markdown-content img:not(.medium-zoom-image)'
     );
     const zoomable = Array.from(candidates).filter(

--- a/app/src/styles/custom.css
+++ b/app/src/styles/custom.css
@@ -608,7 +608,10 @@
 
 /* Hero image — light/dark variant toggle (used by index.mdx and ja/index.mdx) */
 .hero-image picture {
+  display: block;
   width: 100%;
+  max-width: 720px;
+  margin: 1rem auto 2rem;
 }
 .hero-image img {
   width: 100%;


### PR DESCRIPTION
## Summary

Two related UX fixes for image rendering on the home page, following feedback after #143/#144 landed.

### 1. Hero image sizing
The `.hero-image picture` rule had only `width: 100%` with no `max-width`, so the hero stretched to fill the content column. Constrained it to `max-width: 720px` with auto margins so the hero is centered with breathing room above and below.

### 2. Click-to-zoom on linked images
The site uses `medium-zoom` (`ImageZoom.astro`) to enable click-to-zoom on `.sl-markdown-content img`. This was indiscriminately attaching zoom to **every** content image — including card images wrapped in `<a>` (Mastering Genkit / contextlint / Ableton OSC MCP on the home page). Clicking a linked card image opened a zoom overlay instead of following the link.

Fix: filter out images that have an ancestor `<a>` before passing to `mediumZoom()`. Linked images now follow their link as intended.

### 3. Zoom overlay z-index
Even when zoom was correct (hero image, in-body article images), the zoomed image was rendering **behind** Starlight's site header (`z-index: var(--sl-z-index-navbar) = 10`) because `medium-zoom`'s default CSS sets no `z-index`. Added `z-index: 1000` to `.medium-zoom-overlay` and `.medium-zoom-image--opened` so the zoom layer sits above the header.

## Test plan

- [x] `astro check` — 0 errors
- [x] `astro build` — succeeds
- [x] Manual check via `astro preview` (Playwright): home page renders with centered hero, click on Mastering Genkit card follows link, click on hero opens zoom overlay above header

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/koborin-ai/codesmith/site/pr/145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->