### PR TITLE
docs(article/genkit-vs-adk): rebrand scope fix + Reddit lead-in

### DIFF
--- a/app/src/content/docs/ja/tech/genkit-vs-adk.mdx
+++ b/app/src/content/docs/ja/tech/genkit-vs-adk.mdx
@@ -82,8 +82,8 @@ ADK は、高度な AI エージェントシステムの開発に特化したツ
   - Go（2026 年 3 月 v1.0 stable）
   - Java（2026 年 3 月 v1.0 stable）
   - TypeScript（2026 年 4 月 v1.0 stable）
-- **ランタイム**: Cloud Run、GKE など任意のコンテナ環境にデプロイ可能。**Gemini Enterprise Agent Platform**（2026 年 4 月の Cloud Next 26 で旧 Vertex AI Agent Builder からリブランド）の Agent Runtime（旧 Agent Engine）との統合が深い
-- **モデルサポート**: Vertex AI 経由の Gemini、LiteLLM アダプタで他モデルも対応
+- **ランタイム**: Cloud Run、GKE など任意のコンテナ環境にデプロイ可能。**Gemini Enterprise Agent Platform**（2026 年 4 月の Cloud Next 26 で Vertex AI からリブランド・拡張された後継プラットフォーム）の Agent Runtime（旧 Agent Engine）との統合が深い
+- **モデルサポート**: Agent Platform 経由の Gemini、LiteLLM アダプタで他モデルも対応
 - **開発体験**: ローカル開発 UI（`adk web`）、CLI 評価ツール（`adk eval`）
 - **マルチエージェント**: Agent、Tool、Sub-agent、ワークフローオーケストレーションのファーストクラスサポート
 - **エンタープライズ連携**: ApplicationIntegrationToolset で Salesforce、ServiceNow、JIRA、SAP など 100 以上のコネクタを提供。さらに Vertex AI Search Tool、UrlContextTool、SkillToolset、Spanner Admin Toolset、Apigee モデル連携などのビルトインツール群が追加
@@ -118,7 +118,7 @@ Genkit チームは Discord でも「ADK はエージェント構築専用で mu
 | **開発スタイル** | コードで定義したフロー、明示的な制御 | エージェント中心、LLM 駆動のオーケストレーション |
 | **マルチエージェント** | Beta（プロンプトをツール化するパターン）、Middleware で横断的拡張 | ファーストクラス（Sequential / Parallel / Loop、v2.0 Beta で graph-based Workflow） |
 | **デプロイ** | Cloud Run、GKE、Vercel など任意の環境 | 任意の環境、Gemini Enterprise Agent Platform / Agent Runtime との相性が最も良い |
-| **モデル柔軟性** | Genkit プラグインで Gemini / OpenAI / Anthropic / Ollama などを切替 | Vertex AI 経由の Gemini が中心、LiteLLM で他ベンダーも対応 |
+| **モデル柔軟性** | Genkit プラグインで Gemini / OpenAI / Anthropic / Ollama などを切替 | Agent Platform 経由の Gemini が中心、LiteLLM で他ベンダーも対応 |
 | **成熟度** | Node GA（2025-02）、Go GA（2025-09）、Python Beta（2026-02〜）、Dart Preview | Python GA（2025-05）、Go / Java / TS が 2026-03〜04 に v1.0 stable、Python v2.0 Beta |
 
 ### アーキテクチャパターン
@@ -364,4 +364,4 @@ Genkit と ADK は「どちらが良いか」ではなく、補完的なレイ�
 
 <RichLinkCard href="https://github.com/google/agents-cli" title="Agents CLI" description="ADK エージェントの scaffolding / 評価 / デプロイ / observability を担う OSS CLI。" />
 
-<RichLinkCard href="https://cloud.google.com/products/gemini-enterprise-agent-platform" title="Gemini Enterprise Agent Platform" description="旧 Vertex AI Agent Builder。Cloud Next 26 でリブランド。" />
+<RichLinkCard href="https://cloud.google.com/products/gemini-enterprise-agent-platform" title="Gemini Enterprise Agent Platform" description="Vertex AI の進化版として Cloud Next 26 でリブランド。" />

--- a/app/src/content/docs/ja/tech/genkit-vs-adk.mdx
+++ b/app/src/content/docs/ja/tech/genkit-vs-adk.mdx
@@ -19,6 +19,14 @@ Google は AI 開発を支援するオープンソースのフレームワーク
 
 それぞれの特徴を理解し、どちらのフレームワークがプロジェクトに適しているか判断する手助けとなれば幸いです。
 
+**時間がない方向け**：Genkit team が運営する subreddit [`r/GenkitFramework`](https://www.reddit.com/r/GenkitFramework/comments/1t6ib62/genkit_vs_adk_why_google_provides_two_agentic/) には、Genkit 開発元による使い分けの説明があります。
+
+> if you're looking for the rich enterprise features of Agent Platform, and want to build multi-agent standalone systems, ADK is for you.
+>
+> if you're looking to add Gen AI or agentic features into your app, or want to build agents with lower level components especially using a variety of platforms and models, Genkit is the way to go.
+
+これがおおよその結論。本記事は背景・歴史・最新動向・コード例まで踏み込んで補足します。
+
 ---
 
 ## TL;DR
@@ -30,14 +38,7 @@ Google は AI 開発を支援するオープンソースのフレームワーク
 | 設計思想 | 開発者がフローを明示的に制御 | LLM がエージェント間の委譲を動的に決定 |
 | デプロイ先 | Cloud Run、GKE、Vercel など任意の環境 | 任意の環境、Gemini Enterprise Agent Platform との統合が深い |
 
-どちらを選ぶべきかは、解決したい問題の複雑さとチームが得意な言語によって決まります。
-
-**迷ったときの基準**:
-
-- アプリに AI / agentic 機能を埋めたい → Genkit
-- Agent Platform 上で multi-agent システムを組みたい → ADK
-
-両者は統合されておらず、独立した OSS フレームワークとして並走しています。
+どちらを選ぶべきかは、解決したい問題の複雑さとチームが得意な言語によって決まります。両者は統合されておらず、独立した OSS フレームワークとして並走しています。
 
 ---
 

--- a/app/src/content/docs/tech/genkit-vs-adk.mdx
+++ b/app/src/content/docs/tech/genkit-vs-adk.mdx
@@ -17,6 +17,14 @@ Both can leverage Google's large language models (Gemini), but they differ in th
 
 This article compares Genkit and ADK across use cases, platform integrations, model support, development style, and maturity to help you understand the differences and choose the right framework for your project.
 
+**For the time-pressed**: The Genkit team's subreddit [`r/GenkitFramework`](https://www.reddit.com/r/GenkitFramework/comments/1t6ib62/genkit_vs_adk_why_google_provides_two_agentic/) has a clear breakdown of when to use which, written from inside Genkit:
+
+> if you're looking for the rich enterprise features of Agent Platform, and want to build multi-agent standalone systems, ADK is for you.
+>
+> if you're looking to add Gen AI or agentic features into your app, or want to build agents with lower level components especially using a variety of platforms and models, Genkit is the way to go.
+
+That's the gist. The rest of this article fills in background, history, latest moves, and code examples.
+
 ---
 
 ## TL;DR
@@ -28,14 +36,7 @@ This article compares Genkit and ADK across use cases, platform integrations, mo
 | Design Philosophy | Developer explicitly controls the flow | LLM dynamically decides agent delegation |
 | Deployment | Cloud Run, GKE, Vercel, or anywhere | Anywhere, with deep Gemini Enterprise Agent Platform integration |
 
-The choice depends on the complexity of your problem and your team's preferred language.
-
-**Quick rule of thumb**:
-
-- Want to embed AI / agentic features into an app → Genkit
-- Want to build a multi-agent system on Agent Platform → ADK
-
-They're not merged — they're independent OSS frameworks running in parallel.
+The choice depends on the complexity of your problem and your team's preferred language. They're independent OSS frameworks running in parallel, not merged.
 
 ---
 

--- a/app/src/content/docs/tech/genkit-vs-adk.mdx
+++ b/app/src/content/docs/tech/genkit-vs-adk.mdx
@@ -80,8 +80,8 @@ ADK is a toolkit specialized for building sophisticated AI agent systems. It pro
   - Go (v1.0 stable, Mar 2026)
   - Java (v1.0 stable, Mar 2026)
   - TypeScript (v1.0 stable, Apr 2026)
-- **Runtime**: Deploy to any container environment — Cloud Run, GKE, etc. Deep integration with **Gemini Enterprise Agent Platform** (rebranded from Vertex AI Agent Builder at Cloud Next 26, April 2026) and its Agent Runtime (formerly Agent Engine)
-- **Model Support**: Gemini via Vertex AI, plus other models through LiteLLM adapters
+- **Runtime**: Deploy to any container environment — Cloud Run, GKE, etc. Deep integration with **Gemini Enterprise Agent Platform** (the evolution of Vertex AI, rebranded at Cloud Next 26 in April 2026) and its Agent Runtime (formerly Agent Engine)
+- **Model Support**: Gemini via Agent Platform, plus other models through LiteLLM adapters
 - **Developer Experience**: Local dev UI (`adk web`), CLI evaluation tool (`adk eval`)
 - **Multi-agent**: First-class support for Agent, Tool, Sub-agent, and workflow orchestration
 - **Enterprise Connectors**: 100+ connectors via ApplicationIntegrationToolset — Salesforce, ServiceNow, JIRA, SAP, and more. Built-in tools added since: Vertex AI Search Tool, UrlContextTool, SkillToolset, Spanner Admin Toolset, Apigee model integration
@@ -116,7 +116,7 @@ The Genkit team has framed it on Discord as: ADK is purpose-built for agents and
 | **Development Style** | Code-defined flows, explicit control | Agent-centric, LLM-driven orchestration |
 | **Multi-agent** | Beta (prompt-as-tool pattern); Middleware for cross-cutting extensions | First-class (Sequential / Parallel / Loop; graph-based Workflow in v2.0 Beta) |
 | **Deployment** | Cloud Run, GKE, Vercel, anywhere | Anywhere; best fit with Gemini Enterprise Agent Platform / Agent Runtime |
-| **Model Flexibility** | Switch between Gemini / OpenAI / Anthropic / Ollama and more via Genkit plugins | Gemini-centric via Vertex AI, with other vendors via LiteLLM |
+| **Model Flexibility** | Switch between Gemini / OpenAI / Anthropic / Ollama and more via Genkit plugins | Gemini-centric via Agent Platform, with other vendors via LiteLLM |
 | **Maturity** | Node GA (Feb 2025), Go GA (Sep 2025), Python Beta (Feb 2026~), Dart Preview | Python GA (May 2025), Go / Java / TS reached v1.0 stable in Mar-Apr 2026, Python v2.0 in Beta |
 
 ### Architecture Patterns
@@ -362,4 +362,4 @@ Start with Genkit to understand AI fundamentals, then consider ADK when requirem
 
 <RichLinkCard href="https://github.com/google/agents-cli" title="Agents CLI" description="Open-source CLI for ADK agent scaffolding, evaluation, deployment, and observability." />
 
-<RichLinkCard href="https://cloud.google.com/products/gemini-enterprise-agent-platform" title="Gemini Enterprise Agent Platform" description="Formerly Vertex AI Agent Builder. Rebranded at Cloud Next 26." />
+<RichLinkCard href="https://cloud.google.com/products/gemini-enterprise-agent-platform" title="Gemini Enterprise Agent Platform" description="The evolution of Vertex AI, rebranded at Cloud Next 26." />


### PR DESCRIPTION
## Summary

Post-merge follow-up to #146 with two fixes:

- **Correct the rebrand scope**: PR #146 described the move as "Vertex AI Agent Builder → Gemini Enterprise Agent Platform", but Google's official wording is "(formerly Vertex AI)" — i.e., Vertex AI as a whole was rebranded, not just the Agent Builder piece. Updated 6 references across JA/EN to reflect this. "Vertex AI Search Tool" kept as a product name (sources: cloud.google.com/products/gemini-enterprise-agent-platform, cloud.google.com/blog/products/ai-machine-learning/introducing-gemini-enterprise-agent-platform).
- **Add a Reddit lead-in for time-pressed readers**: A short quote from `r/GenkitFramework` (a subreddit run by the Genkit team) is inserted before TL;DR so readers can grab the gist immediately. The previous "Quick rule of thumb" bullets at the end of TL;DR are removed to avoid duplicating the same conclusion.

## Test Plan

- [x] `npm run ci` passed clean (lint + typecheck + test + build, 23 pages)
- [x] `npm run check-images` passed
- [x] Local visual review