### PR TITLE
feat(infra): least-privilege Vertex AI SA for stars-digest

### DIFF
--- a/infra/stacks/shared.go
+++ b/infra/stacks/shared.go
@@ -39,6 +39,7 @@ func Shared(ctx *pulumi.Context) error {
 		"monitoring.googleapis.com",
 		"logging.googleapis.com",
 		"certificatemanager.googleapis.com",
+		"aiplatform.googleapis.com",
 	}
 
 	var apiServices []pulumi.Resource
@@ -357,6 +358,46 @@ func Shared(ctx *pulumi.Context) error {
 			return err
 		}
 	}
+
+	// ========================================
+	// Stars Digest (Vertex AI) least-privilege SA
+	// ========================================
+
+	starsDigestSA, err := serviceaccount.NewAccount(ctx, "stars-digest-sa", &serviceaccount.AccountArgs{
+		Project:     pulumi.String(projectID),
+		AccountId:   pulumi.String("stars-digest"),
+		DisplayName: pulumi.String("stars-digest"),
+		Description: pulumi.String("Service account for the stars-digest GitHub Action to call Vertex AI"),
+	})
+	if err != nil {
+		return err
+	}
+
+	// Reuse the existing pool + subject (koborin-ai/site) so the digest workflow can impersonate this SA.
+	_, err = serviceaccount.NewIAMMember(ctx, "stars-digest-wif-user", &serviceaccount.IAMMemberArgs{
+		ServiceAccountId: starsDigestSA.Name,
+		Role:             pulumi.String("roles/iam.workloadIdentityUser"),
+		Member: pulumi.Sprintf(
+			"principal://iam.googleapis.com/projects/%s/locations/global/workloadIdentityPools/%s/subject/koborin-ai/site",
+			projectNumber,
+			workloadIdentityPool.WorkloadIdentityPoolId,
+		),
+	})
+	if err != nil {
+		return err
+	}
+
+	// Grant only Vertex AI prediction.
+	_, err = projects.NewIAMMember(ctx, "stars-digest-sa-aiplatform-user", &projects.IAMMemberArgs{
+		Project: pulumi.String(projectID),
+		Role:    pulumi.String("roles/aiplatform.user"),
+		Member:  pulumi.Sprintf("serviceAccount:%s", starsDigestSA.Email),
+	})
+	if err != nil {
+		return err
+	}
+
+	ctx.Export("starsDigestServiceAccount", starsDigestSA.Email)
 
 	return nil
 }


### PR DESCRIPTION
## What
Add a dedicated, least-privilege service account for the stars-digest workflow
to call Gemini via Vertex AI (ADC), replacing the Gemini Developer API key.

## Changes (infra/stacks/shared.go)
- Enable `aiplatform.googleapis.com`
- New SA `stars-digest`, granted `roles/aiplatform.user` only
- Bind to the existing WIF pool/provider + subject `koborin-ai/site` via
  `roles/iam.workloadIdentityUser`
- Export `starsDigestServiceAccount` (SA email) for the GitHub secret

## After merge
1. Apply via `release-infra` (stack=shared)
2. Put the `starsDigestServiceAccount` output into repo secret `STARS_DIGEST_SERVICE_ACCOUNT`
3. Follow-up app PR swaps the Dart/CI auth to Vertex

## Notes
Applied through CI/CD (no local `pulumi up`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/koborin-ai/codesmith/site/pr/154"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783263160&installation_id=125032450&pr_number=154&repository=koborin-ai%2Fsite&return_to=https%3A%2F%2Fgithub.com%2Fkoborin-ai%2Fsite%2Fpull%2F154&signature=79d229ff9bf67204839b30edfa4fcca0aaf4afb7a6bdeda89285728d6a345937"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->