### PR TITLE
fix(ci): correct stars repo slug in Stars Digest workflow

### DIFF
--- a/.github/workflows/stars-digest.yml
+++ b/.github/workflows/stars-digest.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout stars (read-only, full history)
         uses: actions/checkout@v6
         with:
-          repository: nozomi-koborinai/stars
+          repository: koborin-ai/stars
           path: .stars
           fetch-depth: 0
 


### PR DESCRIPTION
## Problem
The scheduled **Stars Digest** run failed at the "Checkout stars" step with
404 Not Found: the workflow checked out `nozomi-koborinai/stars`, which does
not exist.

## Fix
Check out `koborin-ai/stars` (the real repo — public, same org as the site).
No token needed: the default `GITHUB_TOKEN` can read the public repo.

## After merge
Re-run **Stars Digest** via `workflow_dispatch` to verify end-to-end and
generate the first edition.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/koborin-ai/codesmith/site/pr/156"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783295811&installation_id=125032450&pr_number=156&repository=koborin-ai%2Fsite&return_to=https%3A%2F%2Fgithub.com%2Fkoborin-ai%2Fsite%2Fpull%2F156&signature=efc7869f4150837b4cf3f07ce3dede719043480c4e635138b2bb54c576bdcb44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->