### PR TITLE
fix(ci): deploy generated edition to dev+prod without image tag collision

### DIFF
--- a/.github/workflows/app-release.yml
+++ b/.github/workflows/app-release.yml
@@ -29,6 +29,10 @@ on:
         description: "Environment to deploy app to"
         required: true
         type: string
+      ref:
+        description: "Git ref to checkout and build (defaults to the triggering SHA)"
+        required: false
+        type: string
 
 # Prevent concurrent deployments to avoid Pulumi state conflicts
 # When multiple triggers occur (e.g., main merge + tag push), jobs queue up
@@ -63,6 +67,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          ref: ${{ inputs.ref || github.sha }}
           # Fetch full Git history for Starlight's lastUpdated feature
           fetch-depth: 0
 
@@ -126,7 +131,7 @@ jobs:
       - name: Build and push Docker image
         id: build-image
         run: |
-          IMAGE_TAG="${GITHUB_SHA}-${GITHUB_RUN_ID}"
+          IMAGE_TAG="${GITHUB_SHA}-${GITHUB_RUN_ID}-${TARGET_ENV}"
           IMAGE_URI="asia-northeast1-docker.pkg.dev/${{ env.PROJECT_ID }}/koborin-ai-web/app:${IMAGE_TAG}"
 
           # Submit entire project (including .git) so Starlight can access Git history

--- a/.github/workflows/stars-digest.yml
+++ b/.github/workflows/stars-digest.yml
@@ -22,6 +22,7 @@ jobs:
       changed: ${{ steps.commit.outputs.changed }}
       tag: ${{ steps.commit.outputs.tag }}
       summary: ${{ steps.gen.outputs.summary }}
+      sha: ${{ steps.commit.outputs.sha }}
     steps:
       - name: Checkout site
         uses: actions/checkout@v6
@@ -83,6 +84,7 @@ jobs:
           git push
           echo "changed=true" >> "$GITHUB_OUTPUT"
           echo "tag=stars-${DATE_JST}" >> "$GITHUB_OUTPUT"
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
   deploy-dev:
     name: Deploy (dev)
@@ -91,6 +93,7 @@ jobs:
     uses: ./.github/workflows/app-release.yml
     with:
       environment: dev
+      ref: ${{ needs.generate.outputs.sha }}
     secrets: inherit
 
   deploy-prod:
@@ -99,6 +102,7 @@ jobs:
     uses: ./.github/workflows/app-release.yml
     with:
       environment: prod
+      ref: ${{ needs.generate.outputs.sha }}
     secrets: inherit
 
   release:


### PR DESCRIPTION
## Problems (run 27046387129)
1. **/stars not updated:** the digest deploy jobs checked out the run's trigger SHA — the commit *before* the generated edition — so the new edition was never built or deployed. (The generate commit is pushed by `GITHUB_TOKEN`, which also does not trigger a fresh app-release run.)
2. **prod failed:** dev and prod ran in the same workflow run and produced the same image tag `${SHA}-${RUN_ID}`; Artifact Registry tag immutability rejected prod's push.

## Fix
- `app-release.yml`: add an optional `ref` workflow_call input and check it out (`ref: ${{ inputs.ref || github.sha }}`); add `-${TARGET_ENV}` to the image tag.
- `stars-digest.yml`: the generate job outputs the edition commit SHA; `deploy-dev` and `deploy-prod` pass it as `ref`.

Normal app deploys are unaffected: they pass no `ref` (checkout uses `github.sha`), and the env-suffixed tag stays unique.

## After merge
Re-run **Stars Digest** via `workflow_dispatch` to confirm dev + prod both deploy the new edition.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/koborin-ai/codesmith/site/pr/157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783350347&installation_id=125032450&pr_number=157&repository=koborin-ai%2Fsite&return_to=https%3A%2F%2Fgithub.com%2Fkoborin-ai%2Fsite%2Fpull%2F157&signature=0af98ec86bc7f44af8d9e281cce8da0e6445a639ad0d65804a8a69e85a4373a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->