### PR TITLE
fix(ci): detect deploy environment from inputs.environment

### DIFF
--- a/.github/workflows/app-release.yml
+++ b/.github/workflows/app-release.yml
@@ -49,7 +49,7 @@ jobs:
       contents: read
     timeout-minutes: 30
 
-    environment: ${{ (startsWith(github.ref, 'refs/tags/app-v') || ((github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') && inputs.environment == 'prod')) && 'production (app)' || 'development (app)' }}
+    environment: ${{ (startsWith(github.ref, 'refs/tags/app-v') || inputs.environment == 'prod') && 'production (app)' || 'development (app)' }}
 
     env:
       PROJECT_ID: ${{ secrets.PROJECT_ID }}
@@ -79,7 +79,7 @@ jobs:
           if [[ "${GITHUB_REF}" == refs/tags/app-v* ]]; then
             TARGET_ENV="prod"
             SERVICE_NAME="koborin-ai-web-prod"
-          elif [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" || "${GITHUB_EVENT_NAME}" == "workflow_call" ]]; then
+          elif [[ -n "${{ inputs.environment }}" ]]; then
             TARGET_ENV="${{ inputs.environment }}"
             if [[ "${TARGET_ENV}" == "prod" ]]; then
               SERVICE_NAME="koborin-ai-web-prod"


### PR DESCRIPTION
## Problem
The scheduled Stars Digest's prod deploy failed pushing image tag `<sha>-<run_id>-dev` — a collision with the dev job's tag.

Root cause: `app-release.yml` decided the environment from `github.event_name == 'workflow_call'`, but for a reusable workflow the event name is the *caller's* event (`schedule` for the cron), never `workflow_call`. So the prod job fell through to the default `dev`, produced a `-dev` tag, and effectively ran as dev.

## Fix
Decide the environment from `inputs.environment` (set for both `workflow_call` and `workflow_dispatch`). push/schedule without inputs still default to dev; `app-v*` tags still map to prod.

## After merge
Re-run Stars Digest via `workflow_dispatch` (or wait for the schedule) and confirm deploy-prod now builds/pushes a `-prod` tag and deploys prod.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/koborin-ai/codesmith/site/pr/158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783387936&installation_id=125032450&pr_number=158&repository=koborin-ai%2Fsite&return_to=https%3A%2F%2Fgithub.com%2Fkoborin-ai%2Fsite%2Fpull%2F158&signature=fa24899c7d533a83821ecd6c9e1afaf3db451b52b648dec4c800cb154d2dec82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->