### PR TITLE
fix(app): restore GFM table rendering after Astro 6.4 upgrade

### DIFF
--- a/app/astro.config.mjs
+++ b/app/astro.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig } from "astro/config";
 import starlight from "@astrojs/starlight";
 import rehypeMermaid from "rehype-mermaid";
+import remarkGfm from "remark-gfm";
 import { sidebar } from "./src/sidebar.ts";
 
 export default defineConfig({
@@ -8,6 +9,7 @@ export default defineConfig({
   srcDir: "src",
   // Static output mode (default) - all pages are pre-rendered at build time
   markdown: {
+    remarkPlugins: [remarkGfm],
     rehypePlugins: [
       [
         rehypeMermaid,


### PR DESCRIPTION
## Summary

- Add `remark-gfm` to `markdown.remarkPlugins` in `astro.config.mjs`
- Restores Markdown pipe tables on the homepage (Highlights, Speaking & Events, Project Experience) and any other MDX pages using GFM tables

## Background

After the Astro 6.4.x lockfile update, CI/production builds stopped parsing GFM tables. Pipe syntax was rendered as plain `<p>| Item | ...</p>` instead of `<table>`. Local dev with stale node_modules (Astro 6.1.x) still looked fine, which made the regression easy to miss.

## Test plan

- [x] `npm run lint` in `app/`
- [x] `npm run build` in `app/`
- [x] Verified `/` and `/ja/` preview output contain 3 `<table>` elements and no raw pipe paragraphs
- [x] Merge and tag `app-v*` to deploy to prod

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/koborin-ai/codesmith/site/pr/164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783438016&installation_id=125032450&pr_number=164&repository=koborin-ai%2Fsite&return_to=https%3A%2F%2Fgithub.com%2Fkoborin-ai%2Fsite%2Fpull%2F164&signature=7bc3147f47b993a2e77ac7b5553322546a61490cceca8a422a738d31f82eac7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->