### PR TITLE
docs: add Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -466,3 +466,55 @@ Rules for AI agents during task execution:
 2. **Resource Cleanup**:
    - Close browser tabs opened for testing when verification is complete.
    - Remove temporary files created during debugging.
+
+## Cursor Cloud specific instructions
+
+### Primary product
+
+The main local runtime is the **Astro + Starlight app** under `app/`. There is no docker-compose, database, or local API backend. Production serves static files via nginx on Cloud Run.
+
+### Toolchain versions
+
+- **Node.js 22** (matches `app-ci.yml`). All npm commands run from `app/`.
+- **Go** (from `infra/go.mod`, currently 1.25+) for `infra/` compile checks only.
+- **Dart** is only required for `tools/stars-digest/` (not needed for website work).
+
+### App development
+
+```bash
+cd app
+npm run dev                 # http://localhost:4321
+npm run lint                # astro check (lint + typecheck + tests)
+npm run check-images
+npm run build               # requires Playwright Chromium (see below)
+npm run preview             # serve dist/ after build
+```
+
+Use **tmux** for long-running processes such as `npm run dev`.
+
+### Playwright (required for full `npm run build`)
+
+CI installs Chromium for Mermaid diagram rendering during production builds. After the VM update script runs `npm ci`, run once per fresh environment:
+
+```bash
+cd app && npx playwright install chromium
+```
+
+`npm run dev` does not need Playwright (Mermaid uses inline SVG in dev).
+
+### Infrastructure
+
+```bash
+cd infra && go build ./... && go vet ./...
+```
+
+Never run `pulumi preview` or `pulumi up` locally. Infra changes go through GitHub Actions only.
+
+### Optional tooling
+
+- **webp / imagemagick**: Used by `app/scripts/optimize-og-images.sh` in CI behavior builds. Not required for local dev or `npm run build`.
+- **Giscus / GA4**: Set `PUBLIC_GISCUS_*` and `PUBLIC_GA_MEASUREMENT_ID` in `app/.env` to mirror production engagement features. The site works without them.
+
+### Stars Digest (secondary)
+
+See `tools/stars-digest/README.md`. Requires Dart SDK, a local clone of the private `koborin-ai/stars` repo, and optionally `GEMINI_API_KEY` (use `--dry-run` for offline stub output).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` so future cloud agents can start the Astro app, run quality checks, and avoid common pitfalls (Playwright for builds, no local Pulumi).

## Context

Environment setup was validated on a fresh VM:

- `npm ci` in `app/` (Node 22)
- `npx playwright install chromium` for full builds
- `npm run lint`, `typecheck`, `test`, `check-images`, and `build` all pass
- `go build ./... && go vet ./...` in `infra/` passes
- Dev server demonstrated: homepage → tech article → Japanese i18n → `/stars`

## VM update script

```
cd app
npm ci
```

Playwright browser install is documented in AGENTS.md (one-time per fresh environment, not in the update script).

## Labels

- `doc`
- `change:structure`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e8270a16-c38a-4b62-8633-a3f4ca7389c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e8270a16-c38a-4b62-8633-a3f4ca7389c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/koborin-ai/codesmith/site/pr/167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783575144&installation_id=125032450&pr_number=167&repository=koborin-ai%2Fsite&return_to=https%3A%2F%2Fgithub.com%2Fkoborin-ai%2Fsite%2Fpull%2F167&signature=15d0059733c2213bac2218c2b648c59b97f26be8f1f3be307f5f8bc2e9fde814"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->