### PR TITLE
fix(ci): pass digest commit SHA to prod deploy in stars-digest

### DIFF
--- a/.github/workflows/stars-digest.yml
+++ b/.github/workflows/stars-digest.yml
@@ -98,7 +98,11 @@ jobs:
 
   deploy-prod:
     name: Deploy (prod)
-    needs: deploy-dev
+    # `generate` must be in `needs` so `needs.generate.outputs.sha` resolves.
+    # Without it, `ref` is empty and app-release falls back to the workflow
+    # trigger SHA (pre-digest commit), which leaves prod one edition behind dev.
+    needs: [generate, deploy-dev]
+    if: needs.generate.outputs.changed == 'true'
     uses: ./.github/workflows/app-release.yml
     with:
       environment: prod


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After the 2026-06-09 Stars Digest run, `dev.koborin.ai/stars` showed the 6/9 edition but `koborin.ai/stars` stopped at 6/8.

GitHub Actions logs for run [27165519656](https://github.com/koborin-ai/site/actions/runs/27165519656):

| Job | `ref` input | Checkout SHA | Content |
| --- | --- | --- | --- |
| Deploy (dev) | `97b5d76` | 6/9 digest commit | Correct |
| Deploy (prod) | *(empty)* | `d340c36` | Previous day (6/8) |

## Root cause

`deploy-prod` passes `ref: ${{ needs.generate.outputs.sha }}` but only declares `needs: deploy-dev`. In GitHub Actions, outputs are only available from jobs listed in `needs`, so `ref` was empty. `app-release.yml` then fell back to `github.sha` — the workflow trigger commit on `main` **before** the digest commit was pushed.

`deploy-dev` works because it has `needs: generate`.

## Fix

- Add `generate` to `deploy-prod.needs`
- Add the same `if: needs.generate.outputs.changed == 'true'` guard as dev

## Immediate remediation (manual)

Until this merges, prod can be caught up by dispatching **App Release** on `main` with `environment: prod` (uses current `main`, which already includes 6/9).

## Labels

- `ci`
- `bug`
- `change:behavior`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e8270a16-c38a-4b62-8633-a3f4ca7389c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e8270a16-c38a-4b62-8633-a3f4ca7389c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/koborin-ai/codesmith/site/pr/168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783575382&installation_id=125032450&pr_number=168&repository=koborin-ai%2Fsite&return_to=https%3A%2F%2Fgithub.com%2Fkoborin-ai%2Fsite%2Fpull%2F168&signature=da2d92e0c478a7b43f5a8d1977c2e706b0a34264df99e5bfa2ec2b56e78a9478"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->