### PR TITLE
feat(infra): add TerraDart shared stack for Pulumi migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ terraform.tfstate.backup
 # Build artifacts
 lib/
 !tools/**/lib/
+!infra/lib/
 *.js.map
 
 # Testing

--- a/infra/.gitignore
+++ b/infra/.gitignore
@@ -1,0 +1,12 @@
+# TerraDart synth output
+tf-out/
+
+# Terraform working files
+.terraform/
+.terraform.lock.hcl
+*.tfstate
+*.tfstate.*
+
+# Dart
+.dart_tool/
+pubspec.lock

--- a/infra/analysis_options.yaml
+++ b/infra/analysis_options.yaml
@@ -1,0 +1,7 @@
+include: package:lints/recommended.yaml
+
+analyzer:
+  language:
+    strict-casts: true
+    strict-inference: true
+    strict-raw-types: true

--- a/infra/bin/synth.dart
+++ b/infra/bin/synth.dart
@@ -1,0 +1,94 @@
+/// Synth entry point for koborin.ai infrastructure stacks.
+///
+/// Run `dart run bin/synth.dart shared` to emit a single `main.tf.json`
+/// under `tf-out/<stack>/`.
+///
+/// Required environment variables:
+/// - `GCP_PROJECT_ID`
+/// - `GCP_PROJECT_NUMBER` (shared stack only)
+library;
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:koborin_ai_infra/shared_stack.dart';
+import 'package:koborin_ai_infra/terraform_variables.dart';
+
+Future<void> main(List<String> args) async {
+  final stackName = args.isNotEmpty ? args.first : 'shared';
+
+  switch (stackName) {
+    case 'shared':
+      await _synthShared();
+      return;
+    default:
+      stderr.writeln(
+        'error: unknown stack "$stackName". Valid stacks: shared',
+      );
+      exit(64);
+  }
+}
+
+Future<void> _synthShared() async {
+  final projectId = Platform.environment['GCP_PROJECT_ID'];
+  final projectNumber = Platform.environment['GCP_PROJECT_NUMBER'];
+
+  if (projectId == null || projectId.isEmpty) {
+    stderr.writeln(
+      'error: set GCP_PROJECT_ID (e.g. GCP_PROJECT_ID=my-proj-123)',
+    );
+    exit(64);
+  }
+  if (projectNumber == null || projectNumber.isEmpty) {
+    stderr.writeln(
+      'error: set GCP_PROJECT_NUMBER for shared stack '
+      '(e.g. GCP_PROJECT_NUMBER=123456789012)',
+    );
+    exit(64);
+  }
+
+  const outputDir = 'tf-out/shared';
+  final stack = SharedStack(
+    projectId: projectId,
+    projectNumber: projectNumber,
+  );
+
+  await _cleanOutputDir(outputDir);
+
+  final result = stack.synth();
+  final tfJson = Map<String, dynamic>.from(result.tfJson)
+    ..['variable'] = sharedStackTerraformVariables;
+
+  if (Platform.environment['TERRAFORM_BACKEND'] == 'gcs') {
+    final terraform = Map<String, dynamic>.from(
+      tfJson['terraform'] as Map<String, dynamic>,
+    );
+    terraform['backend'] = {
+      'gcs': {
+        'bucket':
+            Platform.environment['TERRAFORM_STATE_BUCKET'] ??
+                'n-koborinai-me-backend',
+        'prefix': 'terraform/shared',
+      },
+    };
+    tfJson['terraform'] = terraform;
+  }
+
+  final out = Directory(outputDir);
+  await out.create(recursive: true);
+  await File('${out.path}/main.tf.json').writeAsString(
+    const JsonEncoder.withIndent('  ').convert(tfJson),
+  );
+
+  stdout.writeln('synthesized shared stack to $outputDir/main.tf.json');
+}
+
+Future<void> _cleanOutputDir(String outputDir) async {
+  final dir = Directory(outputDir);
+  if (!dir.existsSync()) {
+    return;
+  }
+  await for (final entity in dir.list()) {
+    await entity.delete(recursive: true);
+  }
+}

--- a/infra/lib/shared_stack.dart
+++ b/infra/lib/shared_stack.dart
@@ -1,0 +1,368 @@
+/// Shared GCP infrastructure for koborin.ai.
+///
+/// Provisions the HTTPS load balancer (dev + prod backends), Artifact
+/// Registry, Workload Identity Federation, IAP access, and deployer IAM.
+/// Mirrors [infra/stacks/shared.go] during the Pulumi → TerraDart migration.
+library;
+
+import 'package:terradart_core/terradart_core.dart';
+import 'package:terradart_google/artifact_registry.dart';
+import 'package:terradart_google/compute.dart';
+import 'package:terradart_google/iam.dart';
+import 'package:terradart_google/iap.dart';
+import 'package:terradart_google/project.dart';
+import 'package:terradart_google/provider.dart';
+
+import 'stack_policy.dart';
+
+const _region = 'asia-northeast1';
+
+/// Shared stack: LB, WIF pool, Artifact Registry, deployer IAM.
+final class SharedStack extends Stack {
+  SharedStack({
+    required String projectId,
+    required String projectNumber,
+  }) : super(
+          providers: [
+            GoogleProvider(project: projectId, region: _region),
+          ],
+        ) {
+    final apiDeps = _enableApis();
+
+    final staticIp = add(
+      GoogleComputeGlobalAddress(
+        localName: 'global_ip',
+        name: TfArg.literal('koborin-ai-global-ip'),
+        addressType: TfArg.literal(GlobalAddressType.external),
+        ipVersion: TfArg.literal(GlobalAddressIpVersion.ipv4),
+        description: TfArg.literal(
+          'Static IP for koborin.ai HTTPS load balancer',
+        ),
+        dependsOn: apiDeps,
+      ),
+    );
+
+    add(
+      GoogleArtifactRegistryRepository(
+        localName: 'artifact_registry',
+        repositoryId: TfArg.literal('koborin-ai-web'),
+        location: TfArg.literal(_region),
+        description: TfArg.literal(
+          'Container images for koborin.ai web application (dev/prod)',
+        ),
+        format: TfArg.literal('DOCKER'),
+        dockerConfig: ArtifactRegistryRepositoryArtifactRegistryDockerConfig(
+          immutableTags: TfArg.literal(true),
+        ),
+        dependsOn: apiDeps,
+      ),
+    );
+
+    final devNeg = add(
+      GoogleComputeRegionNetworkEndpointGroup(
+        localName: 'dev_neg',
+        name: TfArg.literal('koborin-ai-dev-neg'),
+        region: TfArg.literal(_region),
+        networkEndpointType: TfArg.literal(
+          RegionNetworkEndpointGroupType.serverless,
+        ),
+        cloudRun:
+            ComputeRegionNetworkEndpointGroupRegionNetworkEndpointGroupCloudRun(
+          service: TfArg.literal('koborin-ai-web-dev'),
+        ),
+        dependsOn: apiDeps,
+      ),
+    );
+
+    final devBackend = add(
+      GoogleComputeBackendService(
+        localName: 'dev_backend',
+        name: TfArg.literal('koborin-ai-dev-backend'),
+        protocol: TfArg.literal(BackendServiceProtocol.http),
+        loadBalancingScheme: TfArg.literal(
+          LoadBalancingScheme.externalManaged,
+        ),
+        timeoutSec: TfArg.literal(30),
+        customResponseHeaders: TfArg.literal([
+          'X-Robots-Tag: noindex, nofollow',
+        ]),
+        backends: [
+          ComputeBackendServiceBackendServiceBackend(
+            group: TfArg.ref(devNeg.selfLink),
+            balancingMode: BackendServiceBalancingMode.utilization,
+            capacityScaler: TfArg.literal(1.0),
+          ),
+        ],
+        iap: ComputeBackendServiceBackendServiceIap(
+          enabled: TfArg.literal(true),
+          oauth2ClientId: TfArg.variable('oauth_client_id'),
+          oauth2ClientSecret: TfArg.variable('oauth_client_secret'),
+        ),
+        dependsOn: [ResourceDependency(devNeg)],
+      ),
+    );
+
+    add(
+      GoogleIapWebBackendServiceIamBinding(
+        localName: 'dev_iap_access',
+        webBackendService: TfArg.ref(devBackend.nameRef),
+        role: TfArg.literal('roles/iap.httpsResourceAccessor'),
+        members: TfArg.literal([r'user:${var.iap_user}']),
+        dependsOn: [ResourceDependency(devBackend)],
+      ),
+    );
+
+    final prodNeg = add(
+      GoogleComputeRegionNetworkEndpointGroup(
+        localName: 'prod_neg',
+        name: TfArg.literal('koborin-ai-prod-neg'),
+        region: TfArg.literal(_region),
+        networkEndpointType: TfArg.literal(
+          RegionNetworkEndpointGroupType.serverless,
+        ),
+        cloudRun:
+            ComputeRegionNetworkEndpointGroupRegionNetworkEndpointGroupCloudRun(
+          service: TfArg.literal('koborin-ai-web-prod'),
+        ),
+        dependsOn: apiDeps,
+      ),
+    );
+
+    final prodBackend = add(
+      GoogleComputeBackendService(
+        localName: 'prod_backend',
+        name: TfArg.literal('koborin-ai-prod-backend'),
+        protocol: TfArg.literal(BackendServiceProtocol.http),
+        loadBalancingScheme: TfArg.literal(
+          LoadBalancingScheme.externalManaged,
+        ),
+        timeoutSec: TfArg.literal(30),
+        backends: [
+          ComputeBackendServiceBackendServiceBackend(
+            group: TfArg.ref(prodNeg.selfLink),
+            balancingMode: BackendServiceBalancingMode.utilization,
+            capacityScaler: TfArg.literal(1.0),
+          ),
+        ],
+        logConfig: ComputeBackendServiceBackendServiceLogConfig(
+          enable: TfArg.literal(true),
+          sampleRate: TfArg.literal(1.0),
+        ),
+        dependsOn: [ResourceDependency(prodNeg)],
+      ),
+    );
+
+    final sslCert = add(
+      GoogleComputeManagedSslCertificate(
+        localName: 'managed_cert',
+        name: TfArg.literal('koborin-ai-cert'),
+        managed: ComputeManagedSslCertificateManagedSslCertificateConfig(
+          domains: ['koborin.ai', 'dev.koborin.ai'],
+        ),
+        dependsOn: apiDeps,
+      ),
+    );
+
+    final urlMap = add(
+      GoogleComputeUrlMap(
+        localName: 'url_map',
+        name: TfArg.literal('koborin-ai-url-map'),
+        description: TfArg.literal(
+          'Routes traffic to dev/prod backends based on host header',
+        ),
+        defaultService: TfArg.ref(prodBackend.selfLink),
+        hostRules: [
+          ComputeUrlMapUrlMapHostRule(
+            hosts: ['koborin.ai'],
+            pathMatcher: TfArg.literal('prod-matcher'),
+          ),
+          ComputeUrlMapUrlMapHostRule(
+            hosts: ['dev.koborin.ai'],
+            pathMatcher: TfArg.literal('dev-matcher'),
+          ),
+        ],
+        pathMatchers: [
+          ComputeUrlMapUrlMapPathMatcher(
+            name: TfArg.literal('prod-matcher'),
+            defaultService: TfArg.ref(prodBackend.selfLink),
+          ),
+          ComputeUrlMapUrlMapPathMatcher(
+            name: TfArg.literal('dev-matcher'),
+            defaultService: TfArg.ref(devBackend.selfLink),
+          ),
+        ],
+        dependsOn: [
+          ResourceDependency(devBackend),
+          ResourceDependency(prodBackend),
+        ],
+      ),
+    );
+
+    final httpsProxy = add(
+      GoogleComputeTargetHttpsProxy(
+        localName: 'https_proxy',
+        name: TfArg.literal('koborin-ai-https-proxy'),
+        urlMap: TfArg.ref(urlMap.selfLink),
+        sslCertificates: TfArg.literal([sslCert.selfLink.interpolation]),
+        dependsOn: [
+          ResourceDependency(urlMap),
+          ResourceDependency(sslCert),
+        ],
+      ),
+    );
+
+    add(
+      GoogleComputeGlobalForwardingRule(
+        localName: 'forwarding_rule',
+        name: TfArg.literal('koborin-ai-forwarding-rule'),
+        target: TfArg.ref(httpsProxy.selfLink),
+        ipAddress: TfArg.ref(staticIp.addressRef),
+        portRange: TfArg.literal('443'),
+        ipProtocol: TfArg.literal(GlobalForwardingRuleIpProtocol.tcp),
+        loadBalancingScheme: TfArg.literal(
+          GlobalForwardingRuleLoadBalancingScheme.externalManaged,
+        ),
+        networkTier: TfArg.literal(GlobalForwardingRuleNetworkTier.premium),
+        dependsOn: [
+          ResourceDependency(httpsProxy),
+          ResourceDependency(staticIp),
+        ],
+      ),
+    );
+
+    final wifPool = add(
+      GoogleIamWorkloadIdentityPool(
+        localName: 'github_actions_pool',
+        workloadIdentityPoolId: TfArg.literal('github-actions-pool'),
+        displayName: TfArg.literal('github-actions-pool'),
+        description: TfArg.literal(
+          'Workload Identity Pool for GitHub Actions workflows',
+        ),
+      ),
+    );
+
+    add(
+      GoogleIamWorkloadIdentityPoolProvider(
+        localName: 'github_provider',
+        // Short pool id — not the full `name` attribute path.
+        workloadIdentityPoolId: TfArg.literal('github-actions-pool'),
+        workloadIdentityPoolProviderId: TfArg.literal(
+          'actions-firebase-provider',
+        ),
+        displayName: TfArg.literal('github-actions-provider'),
+        description: TfArg.literal('GitHub Actions OIDC provider'),
+        attributeCondition: TfArg.literal(
+          'assertion.repository_owner == "koborin-ai"',
+        ),
+        attributeMapping: TfArg.literal({
+          'google.subject': 'assertion.repository',
+          'attribute.repository_owner': 'assertion.repository_owner',
+        }),
+        oidc: IamWorkloadIdentityPoolProviderOidc(
+          issuerUri: TfArg.literal(
+            'https://token.actions.githubusercontent.com',
+          ),
+        ),
+        dependsOn: [ResourceDependency(wifPool)],
+      ),
+    );
+
+    final githubActionsSa = add(
+      GoogleServiceAccount(
+        localName: 'github_actions_sa',
+        accountId: TfArg.literal('github-actions-service'),
+        displayName: TfArg.literal('github-actions-service'),
+        description: TfArg.literal(
+          'Service account for GitHub Actions to deploy via Pulumi',
+        ),
+      ),
+    );
+
+    final wifPrincipal = _wifPrincipal(projectNumber, 'github-actions-pool');
+
+    add(
+      GoogleServiceAccountIamMember(
+        localName: 'github_wif_user',
+        serviceAccountId: TfArg.ref(githubActionsSa.name),
+        role: TfArg.literal('roles/iam.workloadIdentityUser'),
+        member: TfArg.literal(wifPrincipal),
+        dependsOn: [ResourceDependency(wifPool)],
+      ),
+    );
+
+    for (final role in deployerSaRoles) {
+      final logicalName = _deployerRoleLocalName(role);
+      add(
+        GoogleProjectIamMember(
+          localName: logicalName,
+          project: TfArg.literal(projectId),
+          role: TfArg.literal(role),
+          member: TfArg.ref(githubActionsSa.iamMember),
+        ),
+      );
+    }
+
+    final starsDigestSa = add(
+      GoogleServiceAccount(
+        localName: 'stars_digest_sa',
+        accountId: TfArg.literal('stars-digest'),
+        displayName: TfArg.literal('stars-digest'),
+        description: TfArg.literal(
+          'Service account for the stars-digest GitHub Action to call Vertex AI',
+        ),
+      ),
+    );
+
+    add(
+      GoogleServiceAccountIamMember(
+        localName: 'stars_digest_wif_user',
+        serviceAccountId: TfArg.ref(starsDigestSa.name),
+        role: TfArg.literal('roles/iam.workloadIdentityUser'),
+        member: TfArg.literal(wifPrincipal),
+        dependsOn: [ResourceDependency(wifPool)],
+      ),
+    );
+
+    add(
+      GoogleProjectIamMember(
+        localName: 'stars_digest_sa_aiplatform_user',
+        project: TfArg.literal(projectId),
+        role: TfArg.literal('roles/aiplatform.user'),
+        member: TfArg.ref(starsDigestSa.iamMember),
+      ),
+    );
+
+    addExport(
+      'STARS_DIGEST_SERVICE_ACCOUNT',
+      ResourceIdExport(starsDigestSa.email, emitTerraformOutput: true),
+    );
+  }
+
+  List<ResourceDependency> _enableApis() {
+    final deps = <ResourceDependency>[];
+    for (final api in requiredGcpApis) {
+      final localName = _apiLocalName(api);
+      final svc = add(
+        GoogleProjectService(
+          localName: localName,
+          service: TfArg.literal(api),
+          disableOnDestroy: TfArg.literal(false),
+          disableDependentServices: TfArg.literal(false),
+        ),
+      );
+      deps.add(ResourceDependency(svc));
+    }
+    return deps;
+  }
+
+  static String _apiLocalName(String api) =>
+      'api_${api.replaceAll('.', '_')}';
+
+  static String _deployerRoleLocalName(String role) =>
+      'deployer_sa_${role.replaceAll('.', '_').replaceAll('/', '_')}';
+
+  static String _wifPrincipal(String projectNumber, String poolId) =>
+      'principal://iam.googleapis.com/projects/$projectNumber/'
+      'locations/global/workloadIdentityPools/$poolId/'
+      'subject/koborin-ai/site';
+}

--- a/infra/lib/stack_policy.dart
+++ b/infra/lib/stack_policy.dart
@@ -1,0 +1,37 @@
+// GCP API enablement and deployer IAM policy for the shared stack.
+// Kept separate from SharedStack so the role/API lists are easy to review
+// during import migration and IAM audits.
+
+/// GCP APIs required before any dependent resource can be created.
+const requiredGcpApis = [
+  'run.googleapis.com',
+  'compute.googleapis.com',
+  'iam.googleapis.com',
+  'cloudresourcemanager.googleapis.com',
+  'artifactregistry.googleapis.com',
+  'cloudbuild.googleapis.com',
+  'iap.googleapis.com',
+  'monitoring.googleapis.com',
+  'logging.googleapis.com',
+  'certificatemanager.googleapis.com',
+  'aiplatform.googleapis.com',
+];
+
+/// Roles granted to the GitHub Actions deployer service account.
+const deployerSaRoles = [
+  'roles/artifactregistry.admin',
+  'roles/cloudbuild.builds.builder',
+  'roles/cloudbuild.builds.viewer',
+  'roles/run.admin',
+  'roles/compute.admin',
+  'roles/iap.admin',
+  'roles/logging.admin',
+  'roles/logging.viewer',
+  'roles/monitoring.admin',
+  'roles/resourcemanager.projectIamAdmin',
+  'roles/iam.serviceAccountUser',
+  'roles/iam.serviceAccountAdmin',
+  'roles/iam.workloadIdentityPoolAdmin',
+  'roles/serviceusage.serviceUsageAdmin',
+  'roles/storage.objectAdmin',
+];

--- a/infra/lib/terraform_variables.dart
+++ b/infra/lib/terraform_variables.dart
@@ -1,0 +1,22 @@
+/// Terraform `variable` blocks for the shared stack.
+///
+/// TerraDart emits [TfArg.variable] references in resource args but does not
+/// yet synthesize the matching `variable` blocks (planned for terradart_core
+/// v1.x). [bin/synth.dart] merges this map into `main.tf.json` so the
+/// output is a single JSON root module.
+const Map<String, Map<String, Object>> sharedStackTerraformVariables = {
+  'oauth_client_id': {
+    'type': 'string',
+    'description': 'OAuth 2.0 client ID for IAP on the dev backend service.',
+  },
+  'oauth_client_secret': {
+    'type': 'string',
+    'sensitive': true,
+    'description':
+        'OAuth 2.0 client secret for IAP on the dev backend service.',
+  },
+  'iap_user': {
+    'type': 'string',
+    'description': 'Google account email allowed to access dev via IAP.',
+  },
+};

--- a/infra/pubspec.yaml
+++ b/infra/pubspec.yaml
@@ -1,0 +1,13 @@
+name: koborin_ai_infra
+description: TerraDart infrastructure for koborin.ai (migrating from Pulumi Go).
+publish_to: none
+
+environment:
+  sdk: ^3.6.0
+
+dependencies:
+  terradart_core: ^0.12.2
+  terradart_google: ^0.12.2
+
+dev_dependencies:
+  lints: ^6.0.0


### PR DESCRIPTION
## Summary

- Add TerraDart (`terradart_core` / `terradart_google` ^0.12.2) synth for the `shared` GCP stack under `infra/lib/`
- Emit a single `main.tf.json` via `dart run bin/synth.dart shared`; optional GCS backend when `TERRAFORM_BACKEND=gcs`
- Keep existing Pulumi Go stacks (`infra/stacks/*.go`) during phased migration
- Allow `infra/lib/` in git via root `.gitignore` exception
- Remove one-time `generate-imports.sh` after local import completed

## Import status (done locally)

Shared stack resources were imported into Terraform state at `gs://n-koborinai-me-backend/terraform/shared`. Post-import `terraform plan` reports **No changes.**

Notable fix during import: URL map path matcher names must use hyphens (`prod-matcher`, `dev-matcher`), matching existing Pulumi config.

## Test plan

- [x] `cd infra && dart analyze`
- [x] `dart run bin/synth.dart shared` (with `GCP_PROJECT_ID` / `GCP_PROJECT_NUMBER`)
- [x] `terraform init -reconfigure` + `terraform plan` against GCS backend → no changes after import
- [x] CI: no workflow changes in this PR (Terraform CI cutover is a follow-up)

## Impact

- **Production**: No runtime change from this PR alone; import aligned Terraform state with existing GCP resources
- **Secrets**: `TF_VAR_oauth_client_id`, `TF_VAR_oauth_client_secret`, `TF_VAR_iap_user` remain runtime-only (not baked into synth output)
- **Next phases**: dev stack → prod stack → retire Pulumi Go + wire CI

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/koborin-ai/codesmith/site/pr/169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783602709&installation_id=125032450&pr_number=169&repository=koborin-ai%2Fsite&return_to=https%3A%2F%2Fgithub.com%2Fkoborin-ai%2Fsite%2Fpull%2F169&signature=1b79e03b1619f9c014d89bca4e0d11c51b9688ceb4640fdc3c4ce0e5ecde5b09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->