### PR TITLE
feat(infra): add TerraDart dev stack for Pulumi migration

### DIFF
--- a/infra/bin/synth.dart
+++ b/infra/bin/synth.dart
@@ -1,18 +1,20 @@
 /// Synth entry point for koborin.ai infrastructure stacks.
 ///
-/// Run `dart run bin/synth.dart shared` to emit a single `main.tf.json`
+/// Run `dart run bin/synth.dart <stack>` to emit a single `main.tf.json`
 /// under `tf-out/<stack>/`.
 ///
 /// Required environment variables:
-/// - `GCP_PROJECT_ID`
-/// - `GCP_PROJECT_NUMBER` (shared stack only)
+/// - `GCP_PROJECT_ID` (all stacks)
+/// - `GCP_PROJECT_NUMBER` (shared, dev)
 library;
 
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:koborin_ai_infra/dev_stack.dart';
 import 'package:koborin_ai_infra/shared_stack.dart';
 import 'package:koborin_ai_infra/terraform_variables.dart';
+import 'package:terradart_core/terradart_core.dart';
 
 Future<void> main(List<String> args) async {
   final stackName = args.isNotEmpty ? args.first : 'shared';
@@ -21,31 +23,20 @@ Future<void> main(List<String> args) async {
     case 'shared':
       await _synthShared();
       return;
+    case 'dev':
+      await _synthDev();
+      return;
     default:
       stderr.writeln(
-        'error: unknown stack "$stackName". Valid stacks: shared',
+        'error: unknown stack "$stackName". Valid stacks: shared, dev',
       );
       exit(64);
   }
 }
 
 Future<void> _synthShared() async {
-  final projectId = Platform.environment['GCP_PROJECT_ID'];
-  final projectNumber = Platform.environment['GCP_PROJECT_NUMBER'];
-
-  if (projectId == null || projectId.isEmpty) {
-    stderr.writeln(
-      'error: set GCP_PROJECT_ID (e.g. GCP_PROJECT_ID=my-proj-123)',
-    );
-    exit(64);
-  }
-  if (projectNumber == null || projectNumber.isEmpty) {
-    stderr.writeln(
-      'error: set GCP_PROJECT_NUMBER for shared stack '
-      '(e.g. GCP_PROJECT_NUMBER=123456789012)',
-    );
-    exit(64);
-  }
+  final projectId = _requireEnv('GCP_PROJECT_ID');
+  final projectNumber = _requireEnv('GCP_PROJECT_NUMBER');
 
   const outputDir = 'tf-out/shared';
   final stack = SharedStack(
@@ -53,11 +44,43 @@ Future<void> _synthShared() async {
     projectNumber: projectNumber,
   );
 
+  await _synthStack(
+    outputDir: outputDir,
+    stack: stack,
+    variables: sharedStackTerraformVariables,
+    backendPrefix: 'terraform/shared',
+  );
+}
+
+Future<void> _synthDev() async {
+  final projectId = _requireEnv('GCP_PROJECT_ID');
+  final projectNumber = _requireEnv('GCP_PROJECT_NUMBER');
+
+  const outputDir = 'tf-out/dev';
+  final stack = DevStack(
+    projectId: projectId,
+    projectNumber: projectNumber,
+  );
+
+  await _synthStack(
+    outputDir: outputDir,
+    stack: stack,
+    variables: devStackTerraformVariables,
+    backendPrefix: 'terraform/dev',
+  );
+}
+
+Future<void> _synthStack({
+  required String outputDir,
+  required Stack stack,
+  required Map<String, Map<String, Object>> variables,
+  required String backendPrefix,
+}) async {
   await _cleanOutputDir(outputDir);
 
   final result = stack.synth();
   final tfJson = Map<String, dynamic>.from(result.tfJson)
-    ..['variable'] = sharedStackTerraformVariables;
+    ..['variable'] = variables;
 
   if (Platform.environment['TERRAFORM_BACKEND'] == 'gcs') {
     final terraform = Map<String, dynamic>.from(
@@ -68,7 +91,7 @@ Future<void> _synthShared() async {
         'bucket':
             Platform.environment['TERRAFORM_STATE_BUCKET'] ??
                 'n-koborinai-me-backend',
-        'prefix': 'terraform/shared',
+        'prefix': backendPrefix,
       },
     };
     tfJson['terraform'] = terraform;
@@ -80,7 +103,16 @@ Future<void> _synthShared() async {
     const JsonEncoder.withIndent('  ').convert(tfJson),
   );
 
-  stdout.writeln('synthesized shared stack to $outputDir/main.tf.json');
+  stdout.writeln('synthesized stack to $outputDir/main.tf.json');
+}
+
+String _requireEnv(String name) {
+  final value = Platform.environment[name];
+  if (value == null || value.isEmpty) {
+    stderr.writeln('error: set $name (e.g. $name=my-value)');
+    exit(64);
+  }
+  return value;
 }
 
 Future<void> _cleanOutputDir(String outputDir) async {

--- a/infra/lib/dev_stack.dart
+++ b/infra/lib/dev_stack.dart
@@ -1,0 +1,81 @@
+/// Dev Cloud Run service for koborin.ai.
+///
+/// Mirrors [infra/stacks/dev.go] during the Pulumi → TerraDart migration.
+library;
+
+import 'package:terradart_core/terradart_core.dart';
+import 'package:terradart_google/cloud_run.dart';
+import 'package:terradart_google/provider.dart';
+
+const _region = 'asia-northeast1';
+const _serviceName = 'koborin-ai-web-dev';
+
+/// Dev stack: Cloud Run service + IAP invoker binding.
+final class DevStack extends Stack {
+  DevStack({
+    required String projectId,
+    required String projectNumber,
+  }) : super(
+          providers: [
+            GoogleProvider(project: projectId, region: _region),
+          ],
+        ) {
+    final webDev = add(
+      GoogleCloudRunV2Service(
+        localName: 'web_dev',
+        name: TfArg.literal(_serviceName),
+        location: TfArg.literal(_region),
+        ingress: TfArg.literal(Ingress.internalLoadBalancer),
+        template: CloudRunV2ServiceTemplate(
+          executionEnvironment: TfArg.literal(ExecutionEnvironment.gen2),
+          containers: [
+            CloudRunV2ServiceServiceContainer(
+              image: TfArg.variable('image_uri'),
+              env: [
+                CloudRunV2ServiceEnvVar(
+                  name: TfArg.literal('NODE_ENV'),
+                  source: CloudRunV2ServiceEnvVarFromLiteral(
+                    TfArg.literal('development'),
+                  ),
+                ),
+                CloudRunV2ServiceEnvVar(
+                  name: TfArg.literal('NEXT_PUBLIC_ENV'),
+                  source: CloudRunV2ServiceEnvVarFromLiteral(
+                    TfArg.literal('dev'),
+                  ),
+                ),
+              ],
+              resources: CloudRunV2ServiceContainerResources(
+                startupCpuBoost: TfArg.literal(true),
+                cpuIdle: TfArg.literal(true),
+              ),
+            ),
+          ],
+          scaling: CloudRunV2ServiceTemplateScaling(
+            minInstanceCount: TfArg.literal(0),
+            maxInstanceCount: TfArg.literal(1),
+          ),
+        ),
+        traffic: [
+          CloudRunV2ServiceTraffic(
+            type: TfArg.literal(TrafficTargetAllocationType.latest),
+            percent: TfArg.literal(100),
+          ),
+        ],
+      ),
+    );
+
+    add(
+      GoogleCloudRunV2ServiceIamMember(
+        localName: 'web_dev_iap_invoker',
+        name: TfArg.ref(webDev.nameRef),
+        location: TfArg.literal(_region),
+        role: TfArg.literal('roles/run.invoker'),
+        member: TfArg.literal(
+          'serviceAccount:service-$projectNumber@gcp-sa-iap.iam.gserviceaccount.com',
+        ),
+        dependsOn: [ResourceDependency(webDev)],
+      ),
+    );
+  }
+}

--- a/infra/lib/terraform_variables.dart
+++ b/infra/lib/terraform_variables.dart
@@ -20,3 +20,12 @@ const Map<String, Map<String, Object>> sharedStackTerraformVariables = {
     'description': 'Google account email allowed to access dev via IAP.',
   },
 };
+
+/// Terraform `variable` blocks for the dev stack.
+const Map<String, Map<String, Object>> devStackTerraformVariables = {
+  'image_uri': {
+    'type': 'string',
+    'description':
+        'Container image URI for the dev Cloud Run service (Artifact Registry).',
+  },
+};


### PR DESCRIPTION
## Summary

- Add `infra/lib/dev_stack.dart` — Cloud Run `koborin-ai-web-dev` + IAP invoker IAM (mirrors `infra/stacks/dev.go`)
- Extend `bin/synth.dart` with `dev` stack (`tf-out/dev/main.tf.json`, GCS prefix `terraform/dev`)
- Add `image_uri` Terraform variable for container image updates

## Import status (done locally)

Dev stack imported into `gs://n-koborinai-me-backend/terraform/dev`:

- `google_cloud_run_v2_service.web_dev`
- `google_cloud_run_v2_service_iam_member.web_dev_iap_invoker`

Post-import `terraform plan` → **No changes.** The only in-place change during import was `terraform_labels` (cosmetic).

## Test plan

- [x] `cd infra && dart analyze`
- [x] `dart run bin/synth.dart dev` (with `GCP_PROJECT_ID`, `GCP_PROJECT_NUMBER`)
- [x] `terraform init` + `terraform plan` against GCS backend → no changes after import
- [x] CI cutover (`app-release.yml` / `plan-infra.yml`) — follow-up (Phase 2b or Phase 4)

## Impact

- **Production runtime**: No change from this PR; import aligned Terraform state with existing Cloud Run service
- **Deploy path**: `app-release.yml` still uses Pulumi for dev until CI is switched
- **Next**: prod stack (Phase 3) → retire Pulumi Go + wire CI (Phase 4)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/koborin-ai/codesmith/site/pr/170"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783602978&installation_id=125032450&pr_number=170&repository=koborin-ai%2Fsite&return_to=https%3A%2F%2Fgithub.com%2Fkoborin-ai%2Fsite%2Fpull%2F170&signature=9122e9c8f2b53b3b22a3d4fa2c7ff80b3131f492acff6824ad2b9ef20c65b756"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->