### PR TITLE
docs: align README and agent guides with TerraDart infra

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -269,7 +269,7 @@ When adding or updating dependencies (GitHub Actions, Go modules, npm packages, 
 
 1. **Always check for the latest stable version** before adding a new dependency.
 2. **Use specific major versions** for GitHub Actions (e.g., `@v6` not `@main` or `@latest`).
-3. **Prefer `go-version-file`** over hardcoded Go versions to keep CI in sync with `go.mod`.
+3. **Prefer version pins from project files** (e.g. `pubspec.yaml` for Dart, `go-version-file` for Go in other packages) over hardcoded versions in workflows.
 4. **Verify compatibility** with existing dependencies before upgrading.
 5. **Document breaking changes** in PR descriptions when upgrading major versions.
 
@@ -338,7 +338,7 @@ Examples:
    - Dark/light mode theming is handled by CSS in `app/src/styles/custom.css`.
    - **Do not override Mermaid theme in code blocks** - the global CSS handles theme switching.
    - Keep node labels short to avoid text overlap (especially in `flowchart LR` layouts).
-   - Use simple subgraph labels (avoid long strings like `"Pulumi Backend State - GCS"`).
+   - Use simple subgraph labels (avoid long strings like `"Terraform Backend State - GCS"`).
    - If diagrams look broken in dark mode, check that CSS selectors in `custom.css` cover the generated SVG structure.
 
 6. **Terminology Tables for Abbreviations**:
@@ -369,7 +369,7 @@ Examples:
    - Always specify language for code blocks (e.g., `bash`, `typescript`, `text`).
    - Remove trailing spaces at the end of lines.
    - End files with a single newline (no multiple blank lines at EOF).
-   - Do not use backticks in headings (e.g., use `### infra/stacks/shared.go` instead of ``### `infra/stacks/shared.go` ``).
+   - Do not use backticks in headings (e.g., use `### infra/lib/shared_stack.dart` instead of ``### `infra/lib/shared_stack.dart` ``).
 2. **Content Structure**:
    - Use clear, descriptive headings that reflect the content hierarchy.
    - Keep lists concise and actionable.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Skills are located in `.claude/skills/`:
 - **commit-push-pr**: Commit changes and create pull requests
 - **evaluate-article**: Comprehensive blog article evaluation across 7 dimensions (defensibility, logical organization, practical applicability, structure, communication, controversy risk, human authenticity)
 - **import-command**: Convert Cursor commands to Claude Code skills
-- **import-pulumi**: Import existing GCP resources into Pulumi state
+- **import-pulumi**: Legacy guide for Pulumi state import (historical; infra now uses TerraDart/Terraform)
 - **safe-editing**: Ensure AI agents work in an isolated Git worktree to prevent changes to the main working directory
 - **skill-creator**: Create new Claude Code skills
 - **translate-article**: Translate MDX articles between languages while preserving frontmatter and structure

--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@ flowchart LR
     PROD_NEG --> PROD_CR
     
     GH_WIF -.->|"Authenticate"| WIF
-    WIF -.->|"Impersonate"| PULUMI_SA
-    PULUMI_SA -.->|"Preview/Up"| PULUMI_STATE
+    WIF -.->|"Impersonate"| DEPLOYER_SA
+    DEPLOYER_SA -.->|"plan/apply"| TF_STATE
     
-    style PULUMI_STATE fill:#E8E8E8,color:#000,stroke:#666,stroke-width:2px
+    style TF_STATE fill:#E8E8E8,color:#000,stroke:#666,stroke-width:2px
     style STATE_SHARED fill:#F5F5F5,color:#000
     style STATE_DEV fill:#F5F5F5,color:#000
     style STATE_PROD fill:#F5F5F5,color:#000
@@ -95,7 +95,7 @@ flowchart LR
     style DEV_CR fill:#4A90E2,color:#fff
     style PROD_CR fill:#4A90E2,color:#fff
     style GH_WIF fill:#FFB74D,color:#000
-    style PULUMI_SA fill:#FFB74D,color:#000
+    style DEPLOYER_SA fill:#FFB74D,color:#000
 ```
 
 > DNS is hosted in Cloudflare. Terraform does **not** manage DNS records; add/update `koborin.ai` / `dev.koborin.ai` A records manually whenever the load balancer IP changes.
@@ -157,7 +157,7 @@ flowchart LR
 
 ## Tech Stack
 
-- **Frontend**: Astro with Starlight (documentation theme), TypeScript, Tailwind CSS.
+- **Frontend**: Astro with Starlight (documentation theme), TypeScript.
 - **Content Management**: MDX stored under `app/src/content/docs/` within git. Frontmatter is validated via Zod schemas (from Starlight) to keep metadata type-safe. Drafts can be marked with `draft: true` in frontmatter.
 - **Analytics & o11y**:
   - Google Analytics 4 for baseline PV/engagement.
@@ -166,7 +166,7 @@ flowchart LR
 - **Infrastructure**: TerraDart (Dart) targeting Google Cloud via Terraform.
 - **Stars Digest**: Dart CLI built on Genkit (`genkit` + `genkit_vertexai`) that calls Gemini on Vertex AI to generate the daily `/stars` OSS newsletter. See [Stars Digest](#stars-digest).
 - **CI/CD**: GitHub Actions with Workload Identity. `plan-infra.yml` / `release-infra.yml` drive infra, `app-ci.yml` / `app-release.yml` handle the Astro app, and `stars-digest.yml` runs the daily newsletter.
-- **Testing**: Vitest for app tests, TypeScript compilation for infra, Playwright for future E2E if needed.
+- **Testing**: Vitest for app tests, `dart analyze` for infra, Playwright for Mermaid rendering in production builds.
 - **LLM Context**: Machine-readable `llms.txt` files for AI assistants. Auto-generated at build time.
 
 ## Stars Digest


### PR DESCRIPTION
## Summary

- Update `README.md` diagram labels (`DEPLOYER_SA`, `TF_STATE`), remove stale Tailwind mention, and fix testing line for TerraDart infra
- Refresh `AGENTS.md` examples and dependency guidance to match current `infra/lib/` layout
- Mark `import-pulumi` skill as legacy in `CLAUDE.md` after the TerraDart migration

Architecture articles (`koborin-ai-architecture.mdx`) are intentionally out of scope for this PR.

## Test plan

- [x] Documentation-only change; no build or deploy impact
- [x] Review diff for accuracy against current infra layout

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/koborin-ai/codesmith/site/pr/173"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783612137&installation_id=125032450&pr_number=173&repository=koborin-ai%2Fsite&return_to=https%3A%2F%2Fgithub.com%2Fkoborin-ai%2Fsite%2Fpull%2F173&signature=f705e568cecbb13e0942501e84dff618f9da4ddb88a014829b2aa6ea87c9e1c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->