### PR TITLE
ci: automate PR labels from diff paths and conventional titles

### DIFF
--- a/.github/scripts/compute-pr-labels.sh
+++ b/.github/scripts/compute-pr-labels.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# Computes PR labels from changed file paths and optional PR title.
+#
+# Usage:
+#   PR_TITLE="fix(app): example" ./compute-pr-labels.sh path/to/file1 path/to/file2
+#
+# Output: one label per line (sorted, unique).
+
+set -euo pipefail
+
+PR_TITLE="${PR_TITLE:-}"
+
+is_neutral_path() {
+  case "$1" in
+    *.lock | */package-lock.json | */pubspec.lock) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+is_test_path() {
+  case "$1" in
+    */test/* | */tests/* | *_test.* | *.test.* | *.spec.*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+is_behavior_path() {
+  case "$1" in
+    app/* | content/* | infra/* | plugins/* | .claude-plugin/*) return 0 ;;
+    .github/workflows/*) return 0 ;;
+    tools/stars-digest/*)
+      if is_test_path "$1"; then
+        return 1
+      fi
+      return 0
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+is_structure_path() {
+  case "$1" in
+    README.md | AGENTS.md | CLAUDE.md) return 0 ;;
+    .github/release.yml) return 0 ;;
+    docs/* | .claude/skills/* | .cursor/*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+is_app_path() {
+  case "$1" in
+    app/* | content/* | tools/stars-digest/*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+is_infra_path() {
+  case "$1" in
+    infra/*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+is_doc_path() {
+  case "$1" in
+    docs/* | README.md | AGENTS.md | CLAUDE.md | .claude/skills/*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+is_ci_path() {
+  case "$1" in
+    .github/workflows/* | .github/dependabot.yml | .github/scripts/*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+compute_change_type() {
+  local has_behavior=false
+  local has_classifiable=false
+
+  for file in "$@"; do
+    if is_neutral_path "$file"; then
+      continue
+    fi
+
+    has_classifiable=true
+
+    if is_behavior_path "$file"; then
+      has_behavior=true
+      continue
+    fi
+
+    if is_structure_path "$file" || is_test_path "$file"; then
+      continue
+    fi
+
+    # Unknown paths default to behavior to stay safe.
+    has_behavior=true
+  done
+
+  if [[ "$has_classifiable" == false ]]; then
+    echo "change:behavior"
+    return
+  fi
+
+  if [[ "$has_behavior" == true ]]; then
+    echo "change:behavior"
+  else
+    echo "change:structure"
+  fi
+}
+
+compute_domain_labels() {
+  local labels=()
+
+  for file in "$@"; do
+    if is_app_path "$file"; then labels+=("app"); fi
+    if is_infra_path "$file"; then labels+=("infra"); fi
+    if is_doc_path "$file"; then labels+=("doc"); fi
+    if is_ci_path "$file"; then labels+=("ci"); fi
+  done
+
+  if ((${#labels[@]} == 0)); then
+    return
+  fi
+
+  printf '%s\n' "${labels[@]}" | sort -u
+}
+
+compute_category_label() {
+  local title="$1"
+  if [[ "$title" =~ ^fix ]]; then
+    echo "bug"
+  elif [[ "$title" =~ ^feat ]]; then
+    echo "feature"
+  fi
+}
+
+if (("$#" == 0)); then
+  echo "change:behavior"
+  exit 0
+fi
+
+declare -a all_labels=()
+
+change_type="$(compute_change_type "$@")"
+all_labels+=("$change_type")
+
+while IFS= read -r domain; do
+  all_labels+=("$domain")
+done < <(compute_domain_labels "$@")
+
+category="$(compute_category_label "$PR_TITLE")"
+if [[ -n "$category" ]]; then
+  all_labels+=("$category")
+fi
+
+printf '%s\n' "${all_labels[@]}" | sort -u

--- a/.github/scripts/test-compute-pr-labels.sh
+++ b/.github/scripts/test-compute-pr-labels.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$ROOT/compute-pr-labels.sh"
+
+run_labels() {
+  local title="${1:-}"
+  shift
+  PR_TITLE="$title" bash "$SCRIPT" "$@"
+}
+
+assert_contains() {
+  local output="$1"
+  local expected="$2"
+  if ! grep -qx "$expected" <<<"$output"; then
+    echo "Expected label '$expected' in:" >&2
+    echo "$output" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local output="$1"
+  local unexpected="$2"
+  if grep -qx "$unexpected" <<<"$output"; then
+    echo "Did not expect label '$unexpected' in:" >&2
+    echo "$output" >&2
+    exit 1
+  fi
+}
+
+output="$(run_labels "" app/src/content/docs/tech/foo.mdx)"
+assert_contains "$output" "change:behavior"
+assert_contains "$output" "app"
+
+output="$(run_labels "" AGENTS.md README.md)"
+assert_contains "$output" "change:structure"
+assert_contains "$output" "doc"
+
+output="$(run_labels "" infra/lib/shared_stack.dart)"
+assert_contains "$output" "change:behavior"
+assert_contains "$output" "infra"
+
+output="$(run_labels "" tools/stars-digest/test/persona_builder_test.dart)"
+assert_contains "$output" "change:structure"
+assert_contains "$output" "app"
+
+output="$(run_labels "" tools/stars-digest/prompts/digest.md)"
+assert_contains "$output" "change:behavior"
+assert_contains "$output" "app"
+
+output="$(run_labels "fix(stars-digest): tune prompt" tools/stars-digest/prompts/digest.md)"
+assert_contains "$output" "bug"
+
+output="$(run_labels "feat(infra): add resource" infra/lib/dev_stack.dart)"
+assert_contains "$output" "feature"
+
+output="$(run_labels "" .github/workflows/app-ci.yml)"
+assert_contains "$output" "change:behavior"
+assert_contains "$output" "ci"
+
+output="$(run_labels "" app/src/foo.ts AGENTS.md)"
+assert_contains "$output" "change:behavior"
+assert_not_contains "$output" "change:structure"
+
+echo "All compute-pr-labels tests passed."

--- a/.github/workflows/app-ci.yml
+++ b/.github/workflows/app-ci.yml
@@ -13,6 +13,7 @@ on:
       - ".claude-plugin/**"
       - ".github/workflows/app-ci.yml"
       - ".github/workflows/app-release.yml"
+      - ".github/scripts/compute-pr-labels.sh"
 
 jobs:
   quality:
@@ -23,11 +24,30 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
-      - name: Determine change type (labels)
+      - name: Determine change type (paths)
         id: change-type
         run: |
-          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'change:structure') }}" == "true" ]]; then
+          mapfile -t files < <(
+            git diff --name-only \
+              "${{ github.event.pull_request.base.sha }}" \
+              "${{ github.event.pull_request.head.sha }}"
+          )
+
+          if ((${#files[@]} == 0)); then
+            echo "type=behavior" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          change_label=$(
+            .github/scripts/compute-pr-labels.sh "${files[@]}" \
+              | grep -E '^change:' \
+              | head -n 1
+          )
+
+          if [[ "$change_label" == "change:structure" ]]; then
             echo "type=structure" >> "$GITHUB_OUTPUT"
           else
             echo "type=behavior" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -1,0 +1,108 @@
+name: Label PR
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    name: Apply PR labels
+    runs-on: blacksmith-8vcpu-ubuntu-2404
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Compute labels
+        id: labels
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          mapfile -t files < <(
+            git diff --name-only \
+              "${{ github.event.pull_request.base.sha }}" \
+              "${{ github.event.pull_request.head.sha }}"
+          )
+
+          if ((${#files[@]} == 0)); then
+            echo "labels=change:behavior" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          mapfile -t labels < <(PR_TITLE="$PR_TITLE" .github/scripts/compute-pr-labels.sh "${files[@]}")
+          {
+            echo "labels<<EOF"
+            printf '%s\n' "${labels[@]}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Sync labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const managed = new Set([
+              'change:behavior',
+              'change:structure',
+              'app',
+              'infra',
+              'doc',
+              'ci',
+              'feature',
+              'bug',
+            ]);
+
+            const prNumber = context.payload.pull_request.number;
+            const desired = (process.env.DESIRED_LABELS || '')
+              .split('\n')
+              .map((label) => label.trim())
+              .filter(Boolean);
+
+            const { data: issue } = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            if (issue.labels.some((label) => label.name === 'ignore')) {
+              core.info('PR has ignore label; skipping auto-label sync.');
+              return;
+            }
+
+            const current = issue.labels.map((label) => label.name);
+            const toAdd = desired.filter((label) => !current.includes(label));
+            const toRemove = current.filter(
+              (label) => managed.has(label) && !desired.includes(label),
+            );
+
+            for (const label of toRemove) {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                name: label,
+              });
+            }
+
+            if (toAdd.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                labels: toAdd,
+              });
+            }
+
+            core.info(`Applied labels: ${desired.join(', ') || '(none)'}`);
+        env:
+          DESIRED_LABELS: ${{ steps.labels.outputs.labels }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -404,11 +404,14 @@ Add exactly one:
 
 These are in addition to the existing domain labels (`app`, `infra`, `doc`, etc.).
 
+**Automation**: `.github/workflows/label-pr.yml` applies these labels from the diff (and PR title for `feature` / `bug`) via `.github/scripts/compute-pr-labels.sh`. PRs labeled `ignore` are skipped. Manual overrides are synced on the next `synchronize` unless you keep labels outside the managed set.
+
 ### How CI uses the change type
 
 - **App CI (`.github/workflows/app-ci.yml`)**:
+  - Uses the same path heuristics as `.github/scripts/compute-pr-labels.sh` (not the PR label state), so fast vs full checks do not race with label automation.
   - Default is **Behavior Change** (full checks).
-  - If the PR has `change:structure`, CI runs a **fast** check (skips `npm audit` and `npm run build`).
+  - If the diff is structure-only, CI runs a **fast** check (skips `npm audit` and `npm run build`).
 
 ### Infrastructure (`infra/`)
 
@@ -441,7 +444,7 @@ All five commands must complete successfully with no errors.
 3. For app: `npm run build && npm run lint && npm run typecheck && npm run test && npm run check-images` in `app/` - all must pass.
 4. Ensure all Markdown files pass linting (no MD0xx errors).
 5. Mention any manual GCP steps (e.g., DNS imports, current gaps like IAP enablement) in the PR description.
-6. **Label the PR** based on the diff before requesting review:
+6. **Label the PR** — usually automatic via `label-pr.yml`. Before requesting review, confirm labels match the diff (or add `ignore` to opt out):
    - **Change type** (exactly one, required for CI behavior):
      - `change:behavior` — URLs, output, UI, config, or infra changes that affect users/production.
      - `change:structure` — Internal refactors, renames, or formatting with no external impact. CI skips `npm audit` and `npm run build`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Change type

- [x] `change:behavior` (CI behavior changes)

## Areas

- [x] `ci`
- [x] `doc` (`AGENTS.md`)

## Summary

PR ラベル付けを GitHub Actions で自動化しました。

### 追加したもの

1. **`.github/scripts/compute-pr-labels.sh`**
   - 変更ファイルパスから `change:behavior` / `change:structure` とドメインラベル（`app`, `infra`, `doc`, `ci`）を判定
   - PR タイトルの `fix` / `feat` プレフィックスから `bug` / `feature` を付与
   - 判定ロジックは `AGENTS.md` / `change-type` スキルのヒューリスティクスに準拠

2. **`.github/workflows/label-pr.yml`**
   - PR の `opened` / `synchronize` / `reopened` / `edited` でラベルを同期
   - `ignore` ラベルがある PR はスキップ
   - 管理対象ラベル以外（手動で付けたカスタムラベル）は触らない

3. **`app-ci.yml` の改善**
   - change type 判定を PR ラベルではなく **同じスクリプトのパス判定** に変更
   - ラベル付け workflow とのレースで fast path が効かない問題を解消

### 判定例

| 変更 | ラベル |
|------|--------|
| `app/src/content/docs/**` | `change:behavior`, `app` |
| `AGENTS.md` のみ | `change:structure`, `doc` |
| `tools/stars-digest/prompts/**` | `change:behavior`, `app` |
| `tools/stars-digest/test/**` のみ | `change:structure`, `app` |
| `fix(...):` タイトル | + `bug` |

## Verification

```bash
bash .github/scripts/test-compute-pr-labels.sh
```

## Review notes

- **初回マージ時**: この PR 自体は workflow 未存在のため手動ラベルが必要。マージ後の PR から自動化が効きます。
- **手動オーバーライド**: 管理対象ラベル（`change:*`, `app`, `infra`, `doc`, `ci`, `feature`, `bug`）は次の push で再同期されます。恒久除外は `ignore` ラベルを使用してください。

## Labels

- `change:behavior`
- `ci`
- `doc`
- `feature`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0fdb23ed-1fc3-432c-9203-2fe375e7530a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fdb23ed-1fc3-432c-9203-2fe375e7530a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/koborin-ai/codesmith/site/pr/177"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784596941&installation_id=125032450&pr_number=177&repository=koborin-ai%2Fsite&return_to=https%3A%2F%2Fgithub.com%2Fkoborin-ai%2Fsite%2Fpull%2F177&signature=16fc54f88425ebf65aeee232a4cdddc9ca01baf9a0121cf3896ab8c6c4b88227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->